### PR TITLE
feat : Add i18n support with French first translation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,10 @@ android {
         compose = true
     }
 
+    androidResources {
+        generateLocaleConfig = true
+    }
+
     splits {
         abi {
             enable = false

--- a/app/src/main/java/com/grinch/rivo4/MainActivity.kt
+++ b/app/src/main/java/com/grinch/rivo4/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -116,7 +117,7 @@ class MainActivity : ComponentActivity() {
                                     prefs.setBoolean(PreferenceManager.KEY_PATREON_PROMPT_SHOWN, true)
                                     showPatreonPrompt = false 
                                 },
-                                title = "Support Rivo",
+                                title = stringResource(R.string.patreon_prompt_title),
                                 icon = Icons.Default.Favorite,
                                 confirmButton = {
                                     Button(
@@ -128,7 +129,7 @@ class MainActivity : ComponentActivity() {
                                         modifier = Modifier.fillMaxWidth().height(52.dp),
                                         shape = RoundedCornerShape(16.dp)
                                     ) {
-                                        Text("Support on Patreon", fontWeight = FontWeight.Bold)
+                                        Text(stringResource(R.string.patreon_prompt_confirm), fontWeight = FontWeight.Bold)
                                     }
                                 },
                                 dismissButton = {
@@ -139,12 +140,12 @@ class MainActivity : ComponentActivity() {
                                         },
                                         modifier = Modifier.fillMaxWidth().height(52.dp)
                                     ) {
-                                        Text("Maybe later")
+                                        Text(stringResource(R.string.patreon_prompt_dismiss))
                                     }
                                 }
                             ) {
                                 Text(
-                                    "Rivo is free and open source. If you like the app, please consider supporting its development on Patreon!",
+                                    stringResource(R.string.patreon_prompt_body),
                                     style = MaterialTheme.typography.bodyLarge,
                                     textAlign = TextAlign.Center,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/app/src/main/java/com/grinch/rivo4/controller/BackupViewModel.kt
+++ b/app/src/main/java/com/grinch/rivo4/controller/BackupViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.grinch.rivo4.R
 import com.grinch.rivo4.modal.`interface`.ICallLogRepository
 import com.grinch.rivo4.modal.`interface`.IContactsRepository
 import com.grinch.rivo4.modal.data.CallLogEntry
@@ -52,9 +53,9 @@ class BackupViewModel(
                         writer.write(vCard)
                     }
                 }
-                _status.value = "Contacts exported successfully"
+                _status.value = context.getString(R.string.backup_contacts_export_success)
             } catch (e: Exception) {
-                _status.value = "Export failed: ${e.message}"
+                _status.value = context.getString(R.string.backup_export_failed, e.message)
             }
         }
     }
@@ -99,9 +100,9 @@ class BackupViewModel(
                         }
                     }
                 }
-                _status.value = "Contacts imported successfully"
+                _status.value = context.getString(R.string.backup_contacts_import_success)
             } catch (e: Exception) {
-                _status.value = "Import failed: ${e.message}"
+                _status.value = context.getString(R.string.backup_import_failed, e.message)
             }
         }
     }
@@ -116,9 +117,9 @@ class BackupViewModel(
                         writer.write(jsonString)
                     }
                 }
-                _status.value = "Call logs exported successfully"
+                _status.value = context.getString(R.string.backup_call_logs_export_success)
             } catch (e: Exception) {
-                _status.value = "Export failed: ${e.message}"
+                _status.value = context.getString(R.string.backup_export_failed, e.message)
             }
         }
     }
@@ -133,9 +134,9 @@ class BackupViewModel(
                         callLogRepo.saveCallLog(log)
                     }
                 }
-                _status.value = "Call logs imported successfully"
+                _status.value = context.getString(R.string.backup_call_logs_import_success)
             } catch (e: Exception) {
-                _status.value = "Import failed: ${e.message}"
+                _status.value = context.getString(R.string.backup_import_failed, e.message)
             }
         }
     }

--- a/app/src/main/java/com/grinch/rivo4/controller/CallActivity.kt
+++ b/app/src/main/java/com/grinch/rivo4/controller/CallActivity.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.modal.`interface`.IContactsRepository
 import com.grinch.rivo4.view.screen.ExpressiveCallScreen
@@ -130,8 +132,9 @@ class CallActivity : ComponentActivity() {
                 if (call != null && session != null) {
                     val details = call.details
                     val number = details?.handle?.schemeSpecificPart ?: ""
+                    val unknownLabel = stringResource(R.string.label_unknown)
 
-                    var contactName by remember(number) { mutableStateOf(number.ifEmpty { "Unknown" }) }
+                    var contactName by remember(number, unknownLabel) { mutableStateOf(number.ifEmpty { unknownLabel }) }
                     var photoUri by remember(number) { mutableStateOf<String?>(null) }
 
                     LaunchedEffect(number) {
@@ -160,7 +163,7 @@ class CallActivity : ComponentActivity() {
                         ExpressiveCallScreen(
                             call = targetCall,
                             callState = if (targetCall == call) session?.state ?: Call.STATE_ACTIVE else targetCall.state,
-                            contactName = if (targetCall == call) contactName else (targetCall.details.handle?.schemeSpecificPart ?: "Unknown"),
+                            contactName = if (targetCall == call) contactName else (targetCall.details.handle?.schemeSpecificPart ?: unknownLabel),
                             phoneNumber = targetCall.details.handle?.schemeSpecificPart ?: "",
                             photoUri = if (targetCall == call) photoUri else null,
                             audioState = audioState,

--- a/app/src/main/java/com/grinch/rivo4/controller/CallService.kt
+++ b/app/src/main/java/com/grinch/rivo4/controller/CallService.kt
@@ -246,19 +246,19 @@ class CallService : InCallService() {
         
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(android.R.drawable.ic_menu_close_clear_cancel)
-            .setContentTitle("Blocked Call")
-            .setContentText("Blocked call from $number")
+            .setContentTitle(getString(R.string.notif_blocked_call_title))
+            .setContentText(getString(R.string.notif_blocked_call_text, number))
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setAutoCancel(true)
-        
+
         notificationManager.notify(number.hashCode(), builder.build())
     }
 
     private fun showMissedCallNotification(call: Call) {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(MISSED_CHANNEL_ID, "Missed Calls", NotificationManager.IMPORTANCE_DEFAULT).apply {
+            val channel = NotificationChannel(MISSED_CHANNEL_ID, getString(R.string.notif_channel_missed_calls), NotificationManager.IMPORTANCE_DEFAULT).apply {
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
                 enableVibration(true)
                 setShowBadge(true)
@@ -268,14 +268,14 @@ class CallService : InCallService() {
 
         val handle = call.details.handle
         val number = handle?.schemeSpecificPart ?: ""
-        
+
         val contact = if (number.isNotEmpty()) {
             try {
                 contactsRepository.getContactByNumber(number)
             } catch (e: Exception) { null }
         } else null
-        
-        val contactName = contact?.name ?: number.ifEmpty { "Unknown Number" }
+
+        val contactName = contact?.name ?: number.ifEmpty { getString(R.string.label_unknown_number) }
         val contactPhoto = getContactBitmap(contact?.photoUri)
 
         val telecomManager = getSystemService(Context.TELECOM_SERVICE) as TelecomManager
@@ -291,10 +291,18 @@ class CallService : InCallService() {
 
         val timeString = android.text.format.DateFormat.getTimeFormat(this).format(java.util.Date())
 
+        val missedCallText = buildString {
+            append(getString(R.string.notif_missed_call_text, contactName, timeString))
+            if (simLabel != null) {
+                append(" ")
+                append(getString(R.string.notif_via_sim, simLabel))
+            }
+        }
+
         val builder = NotificationCompat.Builder(this, MISSED_CHANNEL_ID)
             .setSmallIcon(android.R.drawable.sym_call_missed)
-            .setContentTitle("Missed Call")
-            .setContentText("Missed call from $contactName at $timeString${if (simLabel != null) " via $simLabel" else ""}")
+            .setContentTitle(getString(R.string.notif_missed_call_title))
+            .setContentText(missedCallText)
             .setLargeIcon(contactPhoto)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setCategory(NotificationCompat.CATEGORY_MESSAGE)
@@ -412,7 +420,7 @@ class CallService : InCallService() {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(CHANNEL_ID, "Calls", NotificationManager.IMPORTANCE_HIGH).apply {
+            val channel = NotificationChannel(CHANNEL_ID, getString(R.string.notif_channel_calls), NotificationManager.IMPORTANCE_HIGH).apply {
                 lockscreenVisibility = Notification.VISIBILITY_PUBLIC
                 enableVibration(true)
             }
@@ -421,17 +429,17 @@ class CallService : InCallService() {
 
         val handle = call.details.handle
         val number = handle?.schemeSpecificPart ?: ""
-        
+
         val contact = if (number.isNotEmpty()) {
             try {
                 contactsRepository.getContactByNumber(number)
             } catch (e: Exception) { null }
         } else null
-        
+
         val contactName = when {
             contact != null -> contact.name
             number.isNotEmpty() -> number
-            else -> "Unknown Number"
+            else -> getString(R.string.label_unknown_number)
         }
         
         val contactPhoto = getContactBitmap(contact?.photoUri)
@@ -475,21 +483,24 @@ class CallService : InCallService() {
         val audioState = _audioState.value
         val audioRoute = audioState?.route ?: CallAudioState.ROUTE_EARPIECE
         val audioLabel = when (audioRoute) {
-            CallAudioState.ROUTE_SPEAKER -> "Speaker"
+            CallAudioState.ROUTE_SPEAKER -> getString(R.string.audio_route_speaker)
             CallAudioState.ROUTE_BLUETOOTH -> {
                 try {
-                    audioState?.activeBluetoothDevice?.name ?: "Bluetooth"
+                    audioState?.activeBluetoothDevice?.name ?: getString(R.string.audio_route_bluetooth)
                 } catch (e: SecurityException) {
-                    "Bluetooth"
+                    getString(R.string.audio_route_bluetooth)
                 }
             }
-            CallAudioState.ROUTE_WIRED_HEADSET -> "Headset"
-            else -> "Handset"
+            CallAudioState.ROUTE_WIRED_HEADSET -> getString(R.string.audio_route_headset)
+            else -> getString(R.string.audio_route_handset)
         }
 
         val contentText = buildString {
-            if (call.state == Call.STATE_RINGING) append("Incoming call") else append("Active call")
-            if (!simLabel.isNullOrEmpty()) append(" via $simLabel")
+            if (call.state == Call.STATE_RINGING) append(getString(R.string.call_status_incoming)) else append(getString(R.string.notif_active_call))
+            if (!simLabel.isNullOrEmpty()) {
+                append(" ")
+                append(getString(R.string.notif_via_sim, simLabel))
+            }
         }
 
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)

--- a/app/src/main/java/com/grinch/rivo4/controller/util/ContactUtils.kt
+++ b/app/src/main/java/com/grinch/rivo4/controller/util/ContactUtils.kt
@@ -5,16 +5,20 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.SimCard
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.grinch.rivo4.R
 
 object ContactUtils {
+    @Composable
     fun getFriendlyAccountName(account: Account): String {
         return when {
             account.type == "com.google" -> account.name
-            account.type == "com.whatsapp" -> "WhatsApp"
-            account.type.contains("telegram", ignoreCase = true) -> "Telegram"
-            account.type.contains("xiaomi", ignoreCase = true) -> "Mi Account"
-            account.type.contains("sim", ignoreCase = true) -> "SIM Card"
+            account.type == "com.whatsapp" -> stringResource(R.string.brand_whatsapp)
+            account.type.contains("telegram", ignoreCase = true) -> stringResource(R.string.brand_telegram)
+            account.type.contains("xiaomi", ignoreCase = true) -> stringResource(R.string.account_mi_account)
+            account.type.contains("sim", ignoreCase = true) -> stringResource(R.string.account_sim_card)
             account.name.contains("@") -> account.name.substringBefore("@")
             else -> account.name
         }

--- a/app/src/main/java/com/grinch/rivo4/controller/util/utils.kt
+++ b/app/src/main/java/com/grinch/rivo4/controller/util/utils.kt
@@ -16,6 +16,7 @@ import android.telephony.TelephonyManager
 import android.text.format.DateUtils
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import com.grinch.rivo4.R
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -31,16 +32,16 @@ private fun isSameYear(timestamp1: Long, timestamp2: Long): Boolean {
     return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR)
 }
 
-private fun getRelativeDay(timestamp: Long): String? {
+private fun getRelativeDay(context: Context, timestamp: Long): String? {
     return when {
-        DateUtils.isToday(timestamp) -> "Today"
-        isYesterday(timestamp) -> "Yesterday"
+        DateUtils.isToday(timestamp) -> context.getString(R.string.date_today)
+        isYesterday(timestamp) -> context.getString(R.string.date_yesterday)
         else -> null
     }
 }
 
-fun formatDateHeader(timestamp: Long): String {
-    val relative = getRelativeDay(timestamp)
+fun formatDateHeader(context: Context, timestamp: Long): String {
+    val relative = getRelativeDay(context, timestamp)
     if (relative != null) return relative
 
     val pattern = if (isSameYear(timestamp, System.currentTimeMillis())) "MMMM d" else "MMMM d, yyyy"
@@ -48,10 +49,10 @@ fun formatDateHeader(timestamp: Long): String {
 }
 
 fun formatDate(context: Context, timestamp: Long): String {
-    val relative = getRelativeDay(timestamp)
+    val relative = getRelativeDay(context, timestamp)
     val time = android.text.format.DateFormat.getTimeFormat(context).format(Date(timestamp))
 
-    return if (relative != null) "$relative, $time" else "${formatDateHeader(timestamp)}, $time"
+    return if (relative != null) "$relative, $time" else "${formatDateHeader(context, timestamp)}, $time"
 }
 
 fun formatTime(context: Context, timestamp: Long): String {
@@ -201,14 +202,14 @@ fun getAppVersion(context: Context): Pair<String, Long> {
             context.packageManager.getPackageInfo(context.packageName, 0)
         }
 
-        val versionName = packageInfo.versionName ?: "Unknown"
+        val versionName = packageInfo.versionName ?: context.getString(R.string.label_unknown)
         // PackageInfoCompat handles retrieving long version codes safely across old/new API levels
         val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo)
 
         Pair(versionName, versionCode)
     } catch (e: PackageManager.NameNotFoundException) {
         e.printStackTrace()
-        Pair("Unknown", -1L)
+        Pair(context.getString(R.string.label_unknown), -1L)
     }
 }
 

--- a/app/src/main/java/com/grinch/rivo4/modal/data/CallLogFilter.kt
+++ b/app/src/main/java/com/grinch/rivo4/modal/data/CallLogFilter.kt
@@ -1,6 +1,19 @@
 package com.grinch.rivo4.modal.data
 
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.formatDateHeader
+
+@Composable
+fun CallLogFilter.displayLabel(): String = when (this) {
+    CallLogFilter.All -> stringResource(R.string.filter_all)
+    CallLogFilter.Contacts -> stringResource(R.string.nav_contacts)
+    CallLogFilter.Incoming -> stringResource(R.string.call_type_incoming)
+    CallLogFilter.Outgoing -> stringResource(R.string.call_type_outgoing)
+    CallLogFilter.Missed -> stringResource(R.string.call_type_missed)
+}
 
 enum class CallLogFilter {
     All,
@@ -10,7 +23,7 @@ enum class CallLogFilter {
     Missed;
 
     companion object {
-        public fun filter(logs: List<CallLogEntry>, type: CallLogFilter): List<List<CallLogEntry>> {
+        public fun filter(context: Context, logs: List<CallLogEntry>, type: CallLogFilter): List<List<CallLogEntry>> {
             val filteredList = when (type) {
                 All -> logs
                 Contacts -> logs.filter { it.name != null && it.name.isNotEmpty() }
@@ -18,7 +31,7 @@ enum class CallLogFilter {
                 Outgoing -> logs.filter { it.type == android.provider.CallLog.Calls.OUTGOING_TYPE }
                 Missed -> logs.filter { it.type == android.provider.CallLog.Calls.MISSED_TYPE }
             }
-            return filteredList.groupBy { formatDateHeader(it.date) }.values.toList()
+            return filteredList.groupBy { formatDateHeader(context, it.date) }.values.toList()
         }
 
         public fun getNames(): List<String> {

--- a/app/src/main/java/com/grinch/rivo4/modal/repository/CallLogRepository.kt
+++ b/app/src/main/java/com/grinch/rivo4/modal/repository/CallLogRepository.kt
@@ -10,6 +10,7 @@ import android.telecom.TelecomManager
 import android.content.Context
 import android.content.ComponentName
 import android.content.ContentValues
+import com.grinch.rivo4.R
 import com.grinch.rivo4.modal.`interface`.ICallLogRepository
 import com.grinch.rivo4.modal.data.CallLogEntry
 import com.grinch.rivo4.modal.`interface`.IContactsRepository
@@ -125,10 +126,11 @@ class CallLogRepository(
 
         val tempLogs = mutableListOf<CallLogEntry>()
         val simCache = mutableMapOf<String, String>()
+        val unknownLabel = context.getString(R.string.label_unknown)
 
         while (cursor.moveToNext()) {
             val callId = cursor.getLong(idIdx)
-            val number = cursor.getString(numberIdx) ?: "Unknown"
+            val number = cursor.getString(numberIdx) ?: unknownLabel
             val type = cursor.getInt(typeIdx)
             val date = cursor.getLong(dateIdx)
             val duration = cursor.getLong(durationIdx)

--- a/app/src/main/java/com/grinch/rivo4/modal/repository/ContactsRepository.kt
+++ b/app/src/main/java/com/grinch/rivo4/modal/repository/ContactsRepository.kt
@@ -8,6 +8,7 @@ import android.content.ContentValues
 import android.content.Context
 import android.net.Uri
 import android.provider.ContactsContract
+import com.grinch.rivo4.R
 import com.grinch.rivo4.modal.data.Contact
 import com.grinch.rivo4.modal.data.ContactEvent
 import com.grinch.rivo4.modal.`interface`.IContactsRepository
@@ -25,6 +26,7 @@ class ContactsRepository(
 
     private val contentResolver: ContentResolver = context.contentResolver
     private val preferenceManager = com.grinch.rivo4.controller.util.PreferenceManager(context)
+    private val unknownLabel: String get() = context.getString(R.string.label_unknown)
 
     private fun formatName(rawName: String): String {
         return rawName
@@ -79,7 +81,7 @@ class ContactsRepository(
                     } else {
                         contactsMap[id] = Contact(
                             id = id,
-                            name = formatName(cursor.getString(nameIdx) ?: "Unknown"),
+                            name = formatName(cursor.getString(nameIdx) ?: unknownLabel),
                             photoUri = cursor.getString(photoIdx),
                             isFavorite = cursor.getInt(starredIdx) == 1,
                             accountName = cursor.getString(accountNameIdx),
@@ -180,7 +182,7 @@ class ContactsRepository(
 
                     val currentContact = contact ?: Contact(
                         id = id,
-                        name = formatName(cursor.getString(nameIdx) ?: "Unknown"),
+                        name = formatName(cursor.getString(nameIdx) ?: unknownLabel),
                         photoUri = cursor.getString(photoIdx),
                         isFavorite = isStarred,
                         customRingtone = ringtone,
@@ -694,7 +696,7 @@ class ContactsRepository(
                     val ringtoneIdx = cursor.getColumnIndex(ContactsContract.PhoneLookup.CUSTOM_RINGTONE)
 
                     val id = if (idIdx != -1) cursor.getString(idIdx) else "0"
-                    val name = if (nameIdx != -1) cursor.getString(nameIdx) else "Unknown"
+                    val name = if (nameIdx != -1) cursor.getString(nameIdx) else unknownLabel
                     val photoUri = if (photoIdx != -1) cursor.getString(photoIdx) else null
                     val starred = if (starredIdx != -1) cursor.getInt(starredIdx) == 1 else false
                     val ringtone = if (ringtoneIdx != -1) cursor.getString(ringtoneIdx) else null
@@ -918,7 +920,7 @@ class ContactsRepository(
                 if (name.isNotBlank() || numbers.isNotEmpty()) {
                     saveContact(Contact(
                         id = "0",
-                        name = if (name.isBlank()) numbers.firstOrNull() ?: "Unknown" else name,
+                        name = if (name.isBlank()) numbers.firstOrNull() ?: unknownLabel else name,
                         phoneNumbers = numbers,
                         emails = emails,
                         isPrivate = true

--- a/app/src/main/java/com/grinch/rivo4/view/components/AZListScroll.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/AZListScroll.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.modal.data.Contact
 import com.grinch.rivo4.controller.util.ContactUtils
 import com.grinch.rivo4.controller.util.PreferenceManager
@@ -123,10 +125,11 @@ fun AZListScroll(
                 item {
                     Box(modifier = Modifier.padding(horizontal = 16.dp)) {
                         RivoExpressiveCard(isCompact = true) {
+                            val unknownLabel = stringResource(R.string.label_unknown)
                             contactsForChar.forEachIndexed { index, contact ->
                                 val displayName = ContactUtils.formatContactName(
                                     contact.name.ifEmpty {
-                                        contact.phoneNumbers.firstOrNull()?.let { formatPhoneNumber(it) } ?: "Unknown"
+                                        contact.phoneNumbers.firstOrNull()?.let { formatPhoneNumber(it) } ?: unknownLabel
                                     },
                                     displayOrder
                                 )

--- a/app/src/main/java/com/grinch/rivo4/view/components/BottomBar.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/BottomBar.kt
@@ -8,11 +8,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.ramcosta.composedestinations.generated.destinations.ContactScreenDestination
 import com.ramcosta.composedestinations.generated.destinations.RecentScreenDestination
@@ -34,8 +36,8 @@ fun BottomBar(navController: NavController, navigator: DestinationsNavigator) {
     val iconOnly = prefs.getBoolean(PreferenceManager.KEY_ICON_ONLY_NAV, false)
 
     val tabs = listOf(
-        NavigationTab(RecentScreenDestination.route, "Recents", Icons.Default.History, 0),
-        NavigationTab(ContactScreenDestination.route, "Contacts", Icons.Default.Person, 1)
+        NavigationTab(RecentScreenDestination.route, stringResource(R.string.nav_recents), Icons.Default.History, 0),
+        NavigationTab(ContactScreenDestination.route, stringResource(R.string.nav_contacts), Icons.Default.Person, 1)
     )
 
     val organizedTabs = if (flipBar) tabs.reversed() else tabs

--- a/app/src/main/java/com/grinch/rivo4/view/components/CallLauncher.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/CallLauncher.kt
@@ -15,9 +15,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.*
 import com.grinch.rivo4.modal.data.Contact
 import org.koin.compose.koinInject
@@ -34,6 +36,7 @@ class CallLauncher(
 fun rememberCallLauncher(): CallLauncher {
     val context = LocalContext.current
     val prefs = koinInject<PreferenceManager>()
+    val mobileLabel = stringResource(R.string.label_mobile)
     val telecomManager = remember { context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager }
 
     var showSimPicker by remember { mutableStateOf(false) }
@@ -109,13 +112,13 @@ fun rememberCallLauncher(): CallLauncher {
         
         RivoSelectionDialog(
             onDismissRequest = { showNumberPicker = false },
-            title = "Select Number",
+            title = stringResource(R.string.select_number_title),
             items = contact.phoneNumbers,
             itemLabel = { formatPhoneNumber(it) },
             onItemSelected = { selectedNumber ->
                 initiateCall(selectedNumber, contact)
             },
-            itemSupporting = { "Mobile" },
+            itemSupporting = { mobileLabel },
             icon = Icons.Default.Phone,
             itemIcon = { Icons.Default.Phone },
             isSelected = { areNumbersEqual(lastUsed, it) }

--- a/app/src/main/java/com/grinch/rivo4/view/components/CallLogTile.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/CallLogTile.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.formatDate
 import com.grinch.rivo4.controller.util.formatPhoneNumber
 import com.grinch.rivo4.controller.util.formatTime
@@ -62,10 +64,10 @@ fun CallLogTileSimple(
             Box(modifier = Modifier.weight(1f)) {
                 RivoListItem(
                     headline = when (log.type) {
-                        CallLog.Calls.INCOMING_TYPE -> "Incoming"
-                        CallLog.Calls.OUTGOING_TYPE -> "Outgoing"
-                        CallLog.Calls.MISSED_TYPE -> "Missed"
-                        else -> "Call"
+                        CallLog.Calls.INCOMING_TYPE -> stringResource(R.string.call_type_incoming)
+                        CallLog.Calls.OUTGOING_TYPE -> stringResource(R.string.call_type_outgoing)
+                        CallLog.Calls.MISSED_TYPE -> stringResource(R.string.call_type_missed)
+                        else -> stringResource(R.string.action_call)
                     },
                     supporting = buildString {
                         append(formatDate(context, log.date))
@@ -89,7 +91,7 @@ fun CallLogTileSimple(
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.Call,
-                        contentDescription = "Call",
+                        contentDescription = stringResource(R.string.action_call),
                         tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.size(20.dp)
                     )
@@ -179,7 +181,7 @@ fun CallLogTile(
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.Call,
-                        contentDescription = "Call",
+                        contentDescription = stringResource(R.string.action_call),
                         tint = MaterialTheme.colorScheme.primary
                     )
                 }
@@ -214,19 +216,19 @@ fun BatchCallLogActionBar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = onClearSelection) {
-                Icon(Icons.Default.Close, "Clear selection")
+                Icon(Icons.Default.Close, stringResource(R.string.action_clear_selection))
             }
             Text(
-                text = "$selectedCount Selected",
+                text = stringResource(R.string.selection_count_selected, selectedCount),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(1f).padding(start = 8.dp)
             )
             IconButton(onClick = { showClearAllConfirm = true }) {
-                Icon(Icons.Default.DeleteSweep, "Clear all logs")
+                Icon(Icons.Default.DeleteSweep, stringResource(R.string.content_desc_clear_all_logs))
             }
             IconButton(onClick = { showDeleteConfirm = true }) {
-                Icon(Icons.Default.Delete, "Delete selected")
+                Icon(Icons.Default.Delete, stringResource(R.string.content_desc_delete_selected))
             }
         }
     }
@@ -234,24 +236,24 @@ fun BatchCallLogActionBar(
     if (showDeleteConfirm) {
         RivoDialog(
             onDismissRequest = { showDeleteConfirm = false },
-            title = "Delete Call Logs",
+            title = stringResource(R.string.call_log_delete_title),
             icon = Icons.Default.Delete,
             confirmButton = {
                 TextButton(onClick = {
                     onDelete()
                     showDeleteConfirm = false
                 }) {
-                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.action_delete), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirm = false }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         ) {
             Text(
-                "Are you sure you want to delete $selectedCount selected call logs?",
+                stringResource(R.string.call_log_delete_confirm, selectedCount),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
@@ -263,24 +265,24 @@ fun BatchCallLogActionBar(
     if (showClearAllConfirm) {
         RivoDialog(
             onDismissRequest = { showClearAllConfirm = false },
-            title = "Clear All Logs",
+            title = stringResource(R.string.call_log_clear_all_title),
             icon = Icons.Default.DeleteSweep,
             confirmButton = {
                 TextButton(onClick = {
                     onClearAll()
                     showClearAllConfirm = false
                 }) {
-                    Text("Clear All", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.call_log_clear_all_confirm), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showClearAllConfirm = false }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         ) {
             Text(
-                "This will delete your entire call history. This action cannot be undone.",
+                stringResource(R.string.call_log_clear_all_message),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,

--- a/app/src/main/java/com/grinch/rivo4/view/components/EmailLauncher.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/EmailLauncher.kt
@@ -13,8 +13,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.*
 import com.grinch.rivo4.modal.data.Contact
 import org.koin.compose.koinInject
@@ -31,6 +33,7 @@ class EmailLauncher(
 fun rememberEmailLauncher(): EmailLauncher {
     val context = LocalContext.current
     val prefs = koinInject<PreferenceManager>()
+    val emailLabel = stringResource(R.string.label_email)
 
     var showEmailPicker by remember { mutableStateOf(false) }
     var pendingContact by remember { mutableStateOf<Contact?>(null) }
@@ -64,11 +67,11 @@ fun rememberEmailLauncher(): EmailLauncher {
 
         RivoSelectionDialog(
             onDismissRequest = { showEmailPicker = false },
-            title = "Select Email",
+            title = stringResource(R.string.select_email_title),
             items = contact.emails,
             itemLabel = { it },
             onItemSelected = { performFinalEmail(it) },
-            itemSupporting = { "Email" },
+            itemSupporting = { emailLabel },
             icon = Icons.Default.Email,
             itemIcon = { if (it == favEmail) Icons.Default.Star else Icons.Default.Email },
             isSelected = { it == favEmail }

--- a/app/src/main/java/com/grinch/rivo4/view/components/IPhoneFavoritesRow.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/IPhoneFavoritesRow.kt
@@ -34,12 +34,14 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import com.grinch.rivo4.R
 import com.grinch.rivo4.modal.data.Contact
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -296,7 +298,7 @@ fun IPhoneFavoritesRow(
                                         )
                                         Spacer(modifier = Modifier.width(4.dp))
                                         Text(
-                                            text = "Mobile",
+                                            text = stringResource(R.string.label_mobile),
                                             style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
                                             color = Color.White.copy(alpha = 0.7f)
                                         )
@@ -327,7 +329,7 @@ fun IPhoneFavoritesRow(
                         ) {
                             Icon(
                                 imageVector = Icons.Default.Remove,
-                                contentDescription = "Remove Favorite",
+                                contentDescription = stringResource(R.string.content_desc_remove_favorite),
                                 tint = Color.White,
                                 modifier = Modifier.padding(4.dp)
                             )

--- a/app/src/main/java/com/grinch/rivo4/view/components/MessageLauncher.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/MessageLauncher.kt
@@ -12,8 +12,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.*
 import com.grinch.rivo4.modal.data.Contact
 import org.koin.compose.koinInject
@@ -30,6 +32,7 @@ class MessageLauncher(
 fun rememberMessageLauncher(): MessageLauncher {
     val context = LocalContext.current
     val prefs = koinInject<PreferenceManager>()
+    val mobileLabel = stringResource(R.string.label_mobile)
 
     var showNumberPicker by remember { mutableStateOf(false) }
     var pendingContact by remember { mutableStateOf<Contact?>(null) }
@@ -69,13 +72,13 @@ fun rememberMessageLauncher(): MessageLauncher {
         
         RivoSelectionDialog(
             onDismissRequest = { showNumberPicker = false },
-            title = "Select Number",
+            title = stringResource(R.string.select_number_title),
             items = contact.phoneNumbers,
             itemLabel = { formatPhoneNumber(it) },
             onItemSelected = { selectedNumber ->
                 initiateMessage(selectedNumber, contact)
             },
-            itemSupporting = { "Mobile" },
+            itemSupporting = { mobileLabel },
             icon = Icons.AutoMirrored.Filled.Message,
             itemIcon = { Icons.AutoMirrored.Filled.Message },
             isSelected = { areNumbersEqual(lastUsed, it) }

--- a/app/src/main/java/com/grinch/rivo4/view/components/NumberPickerDialog.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/NumberPickerDialog.kt
@@ -3,6 +3,8 @@ package com.grinch.rivo4.view.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Phone
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.grinch.rivo4.R
 
 @Composable
 fun NumberPickerDialog(
@@ -12,7 +14,7 @@ fun NumberPickerDialog(
 ) {
     RivoSelectionDialog(
         onDismissRequest = onDismissRequest,
-        title = "Select Number",
+        title = stringResource(R.string.select_number_title),
         items = numbers,
         itemLabel = { it },
         onItemSelected = onNumberSelected,

--- a/app/src/main/java/com/grinch/rivo4/view/components/PremissionDeniedView.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/PremissionDeniedView.kt
@@ -19,15 +19,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 
 @Composable
 fun PermissionDeniedView(
     icon: ImageVector,
     title: String,
     description: String,
-    buttonText: String = "Grant Permission",
+    buttonText: String = stringResource(R.string.action_grant_permission),
     onGrantClick: () -> Unit
 ) {
     Column(

--- a/app/src/main/java/com/grinch/rivo4/view/components/RivoDialogs.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/RivoDialogs.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import org.koin.compose.koinInject
 
@@ -158,8 +160,8 @@ fun RivoConfirmationDialog(
     onConfirm: () -> Unit,
     title: String,
     message: String,
-    confirmLabel: String = "Confirm",
-    dismissLabel: String = "Cancel",
+    confirmLabel: String = stringResource(R.string.action_confirm),
+    dismissLabel: String = stringResource(R.string.action_cancel),
     icon: ImageVector? = null,
     isDestructive: Boolean = false
 ) {
@@ -223,7 +225,7 @@ fun <T> RivoSelectionDialog(
                 modifier = Modifier.fillMaxWidth().height(52.dp),
                 shape = RoundedCornerShape(16.dp)
             ) {
-                Text("Cancel", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                Text(stringResource(R.string.action_cancel), style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
             }
         }
     ) {
@@ -277,7 +279,7 @@ fun <T> RivoSelectionDialog(
                     if (selected) {
                         Icon(
                             imageVector = Icons.Default.Check,
-                            contentDescription = "Selected",
+                            contentDescription = stringResource(R.string.content_desc_selected_item),
                             tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(24.dp)
                         )

--- a/app/src/main/java/com/grinch/rivo4/view/components/RivoExpressiveUI.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/RivoExpressiveUI.kt
@@ -35,12 +35,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import org.koin.compose.koinInject
 import java.util.Locale
@@ -466,7 +468,7 @@ fun RivoSelectListItem(
 
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = "Select option",
+                contentDescription = stringResource(R.string.content_desc_select_option),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
                 modifier = Modifier.size(20.dp)
             )
@@ -492,6 +494,7 @@ fun RivoFilterChip(
     selected: Boolean,
     onClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    isAllFilter: Boolean = false,
     leadingIcon: @Composable (() -> Unit)? = null
 ) {
     FilterChip(
@@ -512,7 +515,7 @@ fun RivoFilterChip(
             selectedContainerColor = MaterialTheme.colorScheme.primary,
             selectedLabelColor = MaterialTheme.colorScheme.onPrimary
         ),
-        leadingIcon = leadingIcon ?: if (label == "All") {
+        leadingIcon = leadingIcon ?: if (isAllFilter) {
             { Icon(Icons.Default.FilterList, null, Modifier.size(18.dp), tint = if (selected)  MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface) }
         } else null,
         border = null,

--- a/app/src/main/java/com/grinch/rivo4/view/components/ScrollToTopButton.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/ScrollToTopButton.kt
@@ -19,7 +19,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 
 @Composable
 fun ScrollToTopButton(
@@ -43,7 +45,7 @@ fun ScrollToTopButton(
                 ),
                 modifier = Modifier.size(52.dp)
             ) {
-                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "Scroll to top")
+                Icon(Icons.Default.KeyboardArrowUp, contentDescription = stringResource(R.string.content_desc_scroll_to_top))
             }
         }
     }

--- a/app/src/main/java/com/grinch/rivo4/view/components/SimPickerDialog.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/SimPickerDialog.kt
@@ -14,9 +14,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
+import com.grinch.rivo4.R
 
 @Composable
 fun SimPickerDialog(
@@ -37,12 +39,13 @@ fun SimPickerDialog(
     }
 
     if (phoneAccounts.isNotEmpty()) {
+        val unknownSimLabel = stringResource(R.string.sim_picker_unknown_sim)
         RivoSelectionDialog(
             onDismissRequest = onDismissRequest,
-            title = "Select SIM Card",
+            title = stringResource(R.string.sim_picker_title),
             items = phoneAccounts,
             itemLabel = { handle ->
-                telecomManager.getPhoneAccount(handle)?.label?.toString() ?: "Unknown SIM"
+                telecomManager.getPhoneAccount(handle)?.label?.toString() ?: unknownSimLabel
             },
             onItemSelected = onSimSelected,
             itemSupporting = { handle ->

--- a/app/src/main/java/com/grinch/rivo4/view/components/TopBar.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/TopBar.kt
@@ -13,9 +13,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.grinch.rivo4.R
 import com.ramcosta.composedestinations.generated.destinations.SearchScreenDestination
 import com.ramcosta.composedestinations.generated.destinations.SettingsScreenDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
@@ -50,11 +52,11 @@ fun TopBar(navController: NavController, navigator: DestinationsNavigator) {
             ) {
                 Icon(
                     imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
+                    contentDescription = stringResource(R.string.content_desc_search),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Text(
-                    text = "Search in Rivo",
+                    text = stringResource(R.string.top_bar_search_placeholder),
                     textAlign = TextAlign.Center,
                     modifier = Modifier
                         .weight(1f)
@@ -63,14 +65,14 @@ fun TopBar(navController: NavController, navigator: DestinationsNavigator) {
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 IconButton(
-                    onClick = { 
+                    onClick = {
                         navigator.navigate(SettingsScreenDestination)
                     },
                     modifier = Modifier.size(32.dp)
                 ) {
                     Icon(
                         imageVector = Icons.Default.Tune,
-                        contentDescription = "Settings",
+                        contentDescription = stringResource(R.string.settings_title),
                         tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(20.dp)
                     )

--- a/app/src/main/java/com/grinch/rivo4/view/components/VideoLauncher.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/VideoLauncher.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.*
 import com.grinch.rivo4.modal.data.Contact
 import org.koin.compose.koinInject
@@ -29,6 +31,8 @@ class VideoLauncher(
 fun rememberVideoLauncher(): VideoLauncher {
     val context = LocalContext.current
     val prefs = koinInject<PreferenceManager>()
+    val videoCallTitle = stringResource(R.string.video_call_title)
+    val videoCallChooserWith = stringResource(R.string.video_call_chooser_with)
 
     var showAppPicker by remember { mutableStateOf(false) }
     var pendingNumber by remember { mutableStateOf("") }
@@ -44,7 +48,7 @@ fun rememberVideoLauncher(): VideoLauncher {
         try {
             context.startActivity(intent)
         } catch (e: Exception) {
-            val chooser = Intent.createChooser(Intent(Intent.ACTION_VIEW, uri), "Video Call with")
+            val chooser = Intent.createChooser(Intent(Intent.ACTION_VIEW, uri), videoCallChooserWith)
             context.startActivity(chooser)
         }
     }
@@ -58,16 +62,16 @@ fun rememberVideoLauncher(): VideoLauncher {
 
     if (showAppPicker) {
         val apps = listOf(
-            "WhatsApp" to "com.whatsapp",
-            "Google Meet" to "com.google.android.apps.meetings",
-            "Zoom" to "us.zoom.videomeetings",
-            "Telegram" to "org.telegram.messenger"
+            stringResource(R.string.brand_whatsapp) to "com.whatsapp",
+            stringResource(R.string.brand_google_meet) to "com.google.android.apps.meetings",
+            stringResource(R.string.brand_zoom) to "us.zoom.videomeetings",
+            stringResource(R.string.brand_telegram) to "org.telegram.messenger"
         )
 
         RivoSelectionDialog(
             onDismissRequest = { showAppPicker = false },
-            title = "Video Call",
-            items = apps + ("System Video Call" to "system"),
+            title = videoCallTitle,
+            items = apps + (stringResource(R.string.video_call_system) to "system"),
             itemLabel = { it.first },
             onItemSelected = { (name, pkg) ->
                 if (pkg == "system") {
@@ -75,7 +79,7 @@ fun rememberVideoLauncher(): VideoLauncher {
                     val intent = Intent(Intent.ACTION_VIEW, uri).apply {
                         setDataAndType(uri, "vnd.android.cursor.item/video-chat-address")
                     }
-                    context.startActivity(Intent.createChooser(intent, "Video Call"))
+                    context.startActivity(Intent.createChooser(intent, videoCallTitle))
                 } else {
                     launchApp(pkg, pendingNumber)
                 }

--- a/app/src/main/java/com/grinch/rivo4/view/components/tiles/CallLogTile.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/tiles/CallLogTile.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.ContactUtils
 import com.grinch.rivo4.controller.util.formatDate
 import com.grinch.rivo4.modal.data.CallLogEntry
@@ -31,9 +33,9 @@ fun CallLogTile(
     val isMissed = log.types.any { it == CallLog.Calls.MISSED_TYPE } || (log.types.isEmpty() && log.type == CallLog.Calls.MISSED_TYPE)
     val context = LocalContext.current
 
-    val title = log.name?.let { 
+    val title = log.name?.let {
         if (it.isNotEmpty()) ContactUtils.formatContactName(it, displayOrder) else null
-    } ?: log.number.ifEmpty { "Unknown" }
+    } ?: log.number.ifEmpty { stringResource(R.string.label_unknown) }
 
     SingleTile(
         title = title,
@@ -89,7 +91,7 @@ fun CallLogTile(
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Call,
-                    contentDescription = "Call",
+                    contentDescription = stringResource(R.string.action_call),
                     tint = MaterialTheme.colorScheme.primary
                 )
             }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/CallLogs.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/CallLogs.kt
@@ -22,8 +22,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.CallLogViewModel
 import com.grinch.rivo4.controller.util.formatDateHeader
 import com.grinch.rivo4.controller.util.makeCall
@@ -33,6 +35,7 @@ import com.grinch.rivo4.controller.util.areNumbersEqual
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.modal.data.CallLogFilter
 import com.grinch.rivo4.modal.data.CallLogEntry
+import com.grinch.rivo4.modal.data.displayLabel
 import com.grinch.rivo4.view.components.*
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
@@ -115,16 +118,16 @@ fun CallLogFullScreen(
             ) { isSelecting ->
                 if (!isSelecting) {
                     TopAppBar(
-                        title = { 
+                        title = {
                             Text(
-                                if (contactName != null) "History with $contactName" else "Call History", 
+                                if (contactName != null) stringResource(R.string.call_history_with_contact, contactName) else stringResource(R.string.call_history_title),
                                 fontWeight = FontWeight.Bold,
                                 style = MaterialTheme.typography.titleMedium
-                            ) 
+                            )
                         },
                         navigationIcon = {
                             IconButton(onClick = { navigator.navigateUp() }) {
-                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                             }
                         },
                         colors = TopAppBarDefaults.topAppBarColors(
@@ -161,10 +164,10 @@ fun CallLogFullScreen(
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(CallLogFilter.entries) { filter ->
-                        RivoFilterChip(filter.name, selectedFilter == filter, {
+                        RivoFilterChip(filter.displayLabel(), selectedFilter == filter, {
                             _ ->
                             viewModel.setFilter(filter)
-                        })
+                        }, isAllFilter = filter == CallLogFilter.All)
                     }
                 }
 
@@ -182,7 +185,7 @@ fun CallLogFullScreen(
                                 tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
                             )
                             Spacer(Modifier.height(16.dp))
-                            Text("No call history found", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(stringResource(R.string.call_log_no_history_found), color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                 } else {
@@ -196,10 +199,10 @@ fun CallLogFullScreen(
 
                     if (finalLogs.isEmpty()) {
                         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            Text("No calls match this filter", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(stringResource(R.string.call_log_no_filter_match), color = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     } else {
-                        val groupedLogs = finalLogs.groupBy { formatDateHeader(it.date) }
+                        val groupedLogs = finalLogs.groupBy { formatDateHeader(context, it.date) }
 
                         LazyColumn(
                             state = listState,

--- a/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
@@ -55,11 +55,13 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import coil.compose.AsyncImage
 import com.grinch.rivo4.controller.CallService
@@ -72,6 +74,17 @@ import java.util.*
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.time.Duration.Companion.seconds
+
+@Composable
+private fun audioRouteLabel(audioRoute: Int, audioState: CallAudioState?): String {
+    val bluetoothShortLabel = stringResource(R.string.audio_route_bluetooth_short)
+    return when (audioRoute) {
+        CallAudioState.ROUTE_SPEAKER -> stringResource(R.string.audio_route_speaker)
+        CallAudioState.ROUTE_BLUETOOTH -> try { audioState?.activeBluetoothDevice?.name ?: bluetoothShortLabel } catch (e: Exception) { bluetoothShortLabel }
+        CallAudioState.ROUTE_WIRED_HEADSET -> stringResource(R.string.audio_route_headset)
+        else -> stringResource(R.string.audio_route_handset)
+    }
+}
 
 @Composable
 fun ExpressiveCallScreen(
@@ -95,11 +108,12 @@ fun ExpressiveCallScreen(
         allCalls.find { it != call && it.state != Call.STATE_DISCONNECTED }
     }
 
-    val simLabel = remember(call.details.accountHandle) {
-        val handle = call.details.accountHandle
-        if (handle != null) {
+    val accountHandle = call.details.accountHandle
+    val simLabelFallback = accountHandle?.let { stringResource(R.string.call_screen_sim_label, it.id) }
+    val simLabel = remember(accountHandle, simLabelFallback) {
+        if (accountHandle != null) {
             val account = try {
-                telecomManager.getPhoneAccount(handle)
+                telecomManager.getPhoneAccount(accountHandle)
             } catch (e: Exception) {
                 null
             }
@@ -108,7 +122,7 @@ fun ExpressiveCallScreen(
             if (!label.isNullOrEmpty()) {
                 label
             } else {
-                "SIM ${handle.id}"
+                simLabelFallback
             }
         } else {
             null
@@ -152,25 +166,29 @@ fun ExpressiveCallScreen(
 
     if (showAudioPicker) {
         val supported = audioState?.supportedRouteMask ?: 0
-        val options = remember(supported) {
+        val handsetLabel = stringResource(R.string.audio_route_handset)
+        val speakerLabel = stringResource(R.string.audio_route_speaker)
+        val headsetLabel = stringResource(R.string.audio_route_headset)
+        val bluetoothLabel = stringResource(R.string.audio_route_bluetooth)
+        val options = remember(supported, handsetLabel, speakerLabel, headsetLabel, bluetoothLabel) {
             mutableListOf<Pair<String, Int>>().apply {
-                if ((supported and CallAudioState.ROUTE_EARPIECE) != 0) add("Handset" to CallAudioState.ROUTE_EARPIECE)
-                if ((supported and CallAudioState.ROUTE_SPEAKER) != 0) add("Speaker" to CallAudioState.ROUTE_SPEAKER)
-                if ((supported and CallAudioState.ROUTE_WIRED_HEADSET) != 0) add("Headset" to CallAudioState.ROUTE_WIRED_HEADSET)
+                if ((supported and CallAudioState.ROUTE_EARPIECE) != 0) add(handsetLabel to CallAudioState.ROUTE_EARPIECE)
+                if ((supported and CallAudioState.ROUTE_SPEAKER) != 0) add(speakerLabel to CallAudioState.ROUTE_SPEAKER)
+                if ((supported and CallAudioState.ROUTE_WIRED_HEADSET) != 0) add(headsetLabel to CallAudioState.ROUTE_WIRED_HEADSET)
                 if ((supported and CallAudioState.ROUTE_BLUETOOTH) != 0) {
                     val deviceName = try {
                         audioState?.activeBluetoothDevice?.name
                     } catch (e: SecurityException) {
                         null
                     }
-                    add((deviceName ?: "Bluetooth") to CallAudioState.ROUTE_BLUETOOTH)
+                    add((deviceName ?: bluetoothLabel) to CallAudioState.ROUTE_BLUETOOTH)
                 }
             }
         }
 
         RivoSelectionDialog<Pair<String, Int>>(
             onDismissRequest = { showAudioPicker = false },
-            title = "Audio Output",
+            title = stringResource(R.string.audio_output_title),
             items = options,
             itemLabel = { option -> option.first },
             onItemSelected = { option ->
@@ -208,7 +226,8 @@ fun ExpressiveCallScreen(
                 exit = fadeOut() + shrinkVertically()
             ) {
                 otherCall?.let { oc ->
-                    var ocName by remember(oc) { mutableStateOf(oc.details.handle?.schemeSpecificPart ?: "Unknown") }
+                    val unknownLabel = stringResource(R.string.label_unknown)
+                    var ocName by remember(oc, unknownLabel) { mutableStateOf(oc.details.handle?.schemeSpecificPart ?: unknownLabel) }
                     LaunchedEffect(oc) {
                         val number = oc.details.handle?.schemeSpecificPart ?: ""
                         if (number.isNotEmpty()) {
@@ -258,14 +277,14 @@ fun ExpressiveCallScreen(
                                         overflow = TextOverflow.Ellipsis
                                     )
                                     Text(
-                                        text = "On Hold",
+                                        text = stringResource(R.string.call_status_on_hold),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.primary
                                     )
                                 }
                             }
                             IconButton(onClick = { oc.disconnect() }) {
-                                Icon(Icons.Default.CallEnd, contentDescription = "End", tint = Color.Red)
+                                Icon(Icons.Default.CallEnd, contentDescription = stringResource(R.string.action_end), tint = Color.Red)
                             }
                         }
                     }
@@ -294,14 +313,14 @@ fun ExpressiveCallScreen(
                         )
 
                         val statusText = when (callState) {
-                            Call.STATE_DISCONNECTED -> "Call Ended"
-                            Call.STATE_HOLDING -> "On Hold"
+                            Call.STATE_DISCONNECTED -> stringResource(R.string.call_status_ended)
+                            Call.STATE_HOLDING -> stringResource(R.string.call_status_on_hold)
                             Call.STATE_ACTIVE -> formatDuration(callDuration)
-                            Call.STATE_DIALING -> "Calling..."
-                            Call.STATE_RINGING -> "Incoming call"
+                            Call.STATE_DIALING -> stringResource(R.string.call_status_calling)
+                            Call.STATE_RINGING -> stringResource(R.string.call_status_incoming)
                             Call.STATE_DISCONNECTING -> ""
-                            Call.STATE_CONNECTING -> "Connecting..."
-                            else -> "Connecting..."
+                            Call.STATE_CONNECTING -> stringResource(R.string.call_status_connecting)
+                            else -> stringResource(R.string.call_status_connecting)
                         }
 
                         Text(
@@ -372,7 +391,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = if (isMuted) Icons.Default.MicOff else Icons.Default.Mic,
                                 isActive = isMuted,
-                                label = "Mute"
+                                label = stringResource(R.string.action_mute)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 CallService.mute(!isMuted)
@@ -381,7 +400,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = Icons.Default.Dialpad,
                                 isActive = showKeypad,
-                                label = "Keypad"
+                                label = stringResource(R.string.action_keypad)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 showKeypad = !showKeypad
@@ -394,12 +413,7 @@ fun ExpressiveCallScreen(
                                 CallAudioState.ROUTE_WIRED_HEADSET -> Icons.Default.Headset
                                 else -> Icons.Default.Phone
                             }
-                            val audioLabel = when (audioRoute) {
-                                CallAudioState.ROUTE_SPEAKER -> "Speaker"
-                                CallAudioState.ROUTE_BLUETOOTH -> try { audioState?.activeBluetoothDevice?.name ?: "BT" } catch (e: Exception) { "BT" }
-                                CallAudioState.ROUTE_WIRED_HEADSET -> "Headset"
-                                else -> "Handset"
-                            }
+                            val audioLabel = audioRouteLabel(audioRoute, audioState)
                             val hasBluetooth = (audioState?.supportedRouteMask ?: 0 and CallAudioState.ROUTE_BLUETOOTH) != 0
 
                             CallActionButton(
@@ -420,7 +434,7 @@ fun ExpressiveCallScreen(
                                     .size(64.dp)
                                     .background(Color(0xFFF44336), CircleShape)
                             ) {
-                                Icon(Icons.Default.CallEnd, contentDescription = "End", tint = Color.White, modifier = Modifier.size(28.dp))
+                                Icon(Icons.Default.CallEnd, contentDescription = stringResource(R.string.action_end), tint = Color.White, modifier = Modifier.size(28.dp))
                             }
                         }
                     } else {
@@ -433,7 +447,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = if (isMuted) Icons.Default.MicOff else Icons.Default.Mic,
                                 isActive = isMuted,
-                                label = "Mute"
+                                label = stringResource(R.string.action_mute)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 CallService.mute(!isMuted)
@@ -442,7 +456,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = Icons.Default.Dialpad,
                                 isActive = showKeypad,
-                                label = "Keypad"
+                                label = stringResource(R.string.action_keypad)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 showKeypad = !showKeypad
@@ -451,7 +465,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = Icons.AutoMirrored.Filled.Message,
                                 isActive = false,
-                                label = "Message"
+                                label = stringResource(R.string.action_message)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 val intent = Intent(Intent.ACTION_SENDTO).apply {
@@ -475,12 +489,7 @@ fun ExpressiveCallScreen(
                                 else -> Icons.Default.Phone
                             }
 
-                            val audioLabel = when (audioRoute) {
-                                CallAudioState.ROUTE_SPEAKER -> "Speaker"
-                                CallAudioState.ROUTE_BLUETOOTH -> try { audioState?.activeBluetoothDevice?.name ?: "BT" } catch (e: Exception) { "BT" }
-                                CallAudioState.ROUTE_WIRED_HEADSET -> "Headset"
-                                else -> "Handset"
-                            }
+                            val audioLabel = audioRouteLabel(audioRoute, audioState)
 
                             val hasBluetooth = (audioState?.supportedRouteMask ?: 0 and CallAudioState.ROUTE_BLUETOOTH) != 0
 
@@ -496,7 +505,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = Icons.Default.Add,
                                 isActive = false,
-                                label = "Add call"
+                                label = stringResource(R.string.action_add_call)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 if (callState != Call.STATE_HOLDING) {
@@ -509,7 +518,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = if (callState == Call.STATE_HOLDING) Icons.Default.PlayArrow else Icons.Default.Pause,
                                 isActive = callState == Call.STATE_HOLDING,
-                                label = if (callState == Call.STATE_HOLDING) "Resume" else "Hold"
+                                label = if (callState == Call.STATE_HOLDING) stringResource(R.string.action_resume) else stringResource(R.string.action_hold)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 if (callState == Call.STATE_HOLDING) call.unhold() else call.hold()
@@ -533,7 +542,7 @@ fun ExpressiveCallScreen(
                             ),
                             interactionSource = interactionSource
                         ) {
-                            Icon(Icons.Default.CallEnd, contentDescription = "End Call", modifier = Modifier.size(32.dp))
+                            Icon(Icons.Default.CallEnd, contentDescription = stringResource(R.string.action_end_call), modifier = Modifier.size(32.dp))
                         }
                     }
                 }
@@ -553,7 +562,7 @@ fun ExpressiveCallScreen(
                             CallActionButton(
                                 icon = Icons.AutoMirrored.Filled.Message,
                                 isActive = false,
-                                label = "Message"
+                                label = stringResource(R.string.action_message)
                             ) {
                                 view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
                                 try { call.disconnect() } catch (e: Exception) {}
@@ -963,7 +972,7 @@ fun HorizontalSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit) {
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), CircleShape)
     ) {
         Text(
-            "Decline",
+            stringResource(R.string.action_decline),
             modifier = Modifier
                 .align(Alignment.CenterStart)
                 .padding(start = 32.dp)
@@ -974,7 +983,7 @@ fun HorizontalSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit) {
         )
 
         Text(
-            "Answer",
+            stringResource(R.string.action_answer),
             modifier = Modifier
                 .align(Alignment.CenterEnd)
                 .padding(end = 32.dp)
@@ -1122,7 +1131,7 @@ fun VerticalSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit) {
         ) {
             Icon(Icons.Default.KeyboardArrowUp, null, tint = Color.White, modifier = Modifier.size(if (isLandscape) 28.dp else 36.dp))
             Text(
-                "Swipe up to answer",
+                stringResource(R.string.swipe_up_to_answer),
                 style = if (isLandscape) MaterialTheme.typography.titleSmall else MaterialTheme.typography.titleMedium,
                 color = Color.White.copy(alpha = 0.9f),
                 fontWeight = FontWeight.Medium
@@ -1141,7 +1150,7 @@ fun VerticalSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit) {
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                "Swipe down to reject",
+                stringResource(R.string.swipe_down_to_reject),
                 style = if (isLandscape) MaterialTheme.typography.titleSmall else MaterialTheme.typography.titleMedium,
                 color = Color.White.copy(alpha = 0.9f),
                 fontWeight = FontWeight.Medium
@@ -1291,40 +1300,40 @@ fun IPhoneSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit, onMessage: 
                         )
                 ) {
                     Icon(
-                        Icons.Default.CallEnd, 
-                        contentDescription = "Decline", 
+                        Icons.Default.CallEnd,
+                        contentDescription = stringResource(R.string.action_decline),
                         tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(24.dp)
                     )
                 }
                 Text(
-                    "Decline", 
-                    style = MaterialTheme.typography.labelMedium, 
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f), 
+                    stringResource(R.string.action_decline),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                     modifier = Modifier.padding(top = 4.dp)
                 )
             }
-            
+
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 IconButton(
                     onClick = onMessage,
                     modifier = Modifier
                         .size(if (isLandscape) 48.dp else 60.dp)
                         .background(
-                            MaterialTheme.colorScheme.onSurface.copy(alpha = if (isDark) 0.15f else 0.1f), 
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = if (isDark) 0.15f else 0.1f),
                             CircleShape
                         )
                 ) {
                     Icon(
-                        Icons.AutoMirrored.Filled.Message, 
-                        contentDescription = "Message", 
+                        Icons.AutoMirrored.Filled.Message,
+                        contentDescription = stringResource(R.string.action_message),
                         tint = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.size(24.dp)
                     )
                 }
                 Text(
-                    "Message", 
-                    style = MaterialTheme.typography.labelMedium, 
+                    stringResource(R.string.action_message),
+                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
                     modifier = Modifier.padding(top = 4.dp)
                 )
@@ -1354,7 +1363,7 @@ fun IPhoneSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit, onMessage: 
             )
 
             Text(
-                text = "slide to answer",
+                text = stringResource(R.string.slide_to_answer),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = handleSize + 16.dp)
@@ -1443,13 +1452,13 @@ fun IncomingCallButtons(onAnswer: () -> Unit, onDecline: () -> Unit) {
             ) {
                 Icon(
                     Icons.Default.CallEnd,
-                    contentDescription = "Decline",
+                    contentDescription = stringResource(R.string.action_decline),
                     modifier = Modifier.size(32.dp)
                 )
             }
             Spacer(modifier = Modifier.height(12.dp))
             Text(
-                text = "Decline",
+                text = stringResource(R.string.action_decline),
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.Medium
@@ -1476,14 +1485,14 @@ fun IncomingCallButtons(onAnswer: () -> Unit, onDecline: () -> Unit) {
                 ) {
                     Icon(
                         Icons.Default.Call,
-                        contentDescription = "Answer",
+                        contentDescription = stringResource(R.string.action_answer),
                         modifier = Modifier.size(32.dp).graphicsLayer(scaleY = -1f)
                     )
                 }
             }
             Spacer(modifier = Modifier.height(12.dp))
             Text(
-                text = "Answer",
+                text = stringResource(R.string.action_answer),
                 color = MaterialTheme.colorScheme.onSurface,
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = FontWeight.Medium

--- a/app/src/main/java/com/grinch/rivo4/view/screen/Contact.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/Contact.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -33,6 +34,7 @@ import androidx.navigation.NavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.ContactUtils
 import com.grinch.rivo4.view.components.AZListScroll
@@ -123,7 +125,7 @@ fun ContactScreen(navController: NavController, navigator: DestinationsNavigator
                     shape = RoundedCornerShape(24.dp),
                     elevation = FloatingActionButtonDefaults.elevation(0.dp)
                 ) {
-                    Icon(Icons.Default.PersonAdd, "Add Contact")
+                    Icon(Icons.Default.PersonAdd, stringResource(R.string.action_add_contact))
                 }
             }
         },
@@ -179,19 +181,19 @@ fun AccountFilterBar(viewModel: ContactsViewModel) {
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         item {
-            RivoFilterChip("All", selectedAccount == null && !showPrivateOnly && !showLocalOnly, {
+            RivoFilterChip(stringResource(R.string.filter_all), selectedAccount == null && !showPrivateOnly && !showLocalOnly, {
                 viewModel.selectAccount(null)
                 viewModel.setShowPrivateOnly(false)
                 viewModel.setShowLocalOnly(false)
-            })
+            }, isAllFilter = true)
         }
         item {
-            RivoFilterChip("Local Memory", showLocalOnly, {
+            RivoFilterChip(stringResource(R.string.label_local_memory), showLocalOnly, {
                 viewModel.setShowLocalOnly(true)
             })
         }
         item {
-            RivoFilterChip("Private", showPrivateOnly, {
+            RivoFilterChip(stringResource(R.string.contact_filter_private), showPrivateOnly, {
                 viewModel.setShowPrivateOnly(true)
             })
         }
@@ -231,19 +233,19 @@ fun BatchActionBar(
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = onClear) {
-                Icon(Icons.Default.Close, "Clear selection")
+                Icon(Icons.Default.Close, stringResource(R.string.action_clear_selection))
             }
             Text(
-                text = "$selectedCount Selected",
+                text = stringResource(R.string.selection_count_selected, selectedCount),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(1f).padding(start = 8.dp)
             )
             IconButton(onClick = { showMoveDialog = true }) {
-                Icon(Icons.AutoMirrored.Filled.DriveFileMove, "Move")
+                Icon(Icons.AutoMirrored.Filled.DriveFileMove, stringResource(R.string.content_desc_move))
             }
             IconButton(onClick = onDelete) {
-                Icon(Icons.Default.Delete, "Delete")
+                Icon(Icons.Default.Delete, stringResource(R.string.action_delete))
             }
         }
     }
@@ -251,11 +253,11 @@ fun BatchActionBar(
     if (showMoveDialog) {
         RivoDialog(
             onDismissRequest = { showMoveDialog = false },
-            title = "Move to Storage",
+            title = stringResource(R.string.contact_move_to_storage),
             icon = Icons.AutoMirrored.Filled.DriveFileMove,
             dismissButton = {
                 TextButton(onClick = { showMoveDialog = false }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         ) {
@@ -286,12 +288,12 @@ fun BatchActionBar(
                     Spacer(Modifier.width(16.dp))
                     Column {
                         Text(
-                            "Private Storage",
+                            stringResource(R.string.contact_move_private_storage_title),
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            "App-only storage",
+                            stringResource(R.string.contact_move_private_storage_supporting),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -326,12 +328,12 @@ fun BatchActionBar(
                     Spacer(Modifier.width(16.dp))
                     Column {
                         Text(
-                            "Local Memory",
+                            stringResource(R.string.label_local_memory),
                             style = MaterialTheme.typography.bodyLarge,
                             fontWeight = FontWeight.SemiBold
                         )
                         Text(
-                            "Device only",
+                            stringResource(R.string.contact_move_local_memory_supporting),
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -465,12 +467,12 @@ fun EmptyContactsState() {
         }
         Spacer(modifier = Modifier.height(24.dp))
         Text(
-            text = "No contacts found",
+            text = stringResource(R.string.contacts_empty_title),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = "Try clearing your filters or add a new contact.",
+            text = stringResource(R.string.empty_state_try_clearing_filters),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
@@ -505,7 +507,7 @@ fun PermissionRequiredState(onRequestPermission: () -> Unit) {
         Text(
             modifier = Modifier.padding(horizontal = 32.dp),
             textAlign = TextAlign.Center,
-            text = "To show your contact list and identify incoming calls, Rivo needs permission to access your contacts.",
+            text = stringResource(R.string.contacts_permission_rationale),
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Medium
         )
@@ -515,7 +517,7 @@ fun PermissionRequiredState(onRequestPermission: () -> Unit) {
             shape = RoundedCornerShape(24.dp),
             elevation = ButtonDefaults.buttonElevation(0.dp)
         ) {
-            Text("Grant permission")
+            Text(stringResource(R.string.action_grant_permission_lower))
         }
     }
 }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/ContactDetails.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/ContactDetails.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -43,6 +44,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.CallLogViewModel
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.*
@@ -106,8 +108,10 @@ fun ContactDetailsScreen(
         }
     }
 
-    val displayPhone = phoneNumber ?: fullContact?.phoneNumbers?.firstOrNull() ?: "Unknown"
-    val displayName = fullContact?.name ?: phoneNumber ?: "Unknown"
+    val unknownLabel = stringResource(R.string.label_unknown)
+    val displayPhone = phoneNumber ?: fullContact?.phoneNumbers?.firstOrNull() ?: unknownLabel
+    val displayName = fullContact?.name ?: phoneNumber ?: unknownLabel
+    val shareContactLabel = stringResource(R.string.contact_share)
 
     val context = LocalContext.current
     val callLauncher = rememberCallLauncher()
@@ -163,12 +167,13 @@ fun ContactDetailsScreen(
     val openTelegram = { num: String -> SocialUtils.openTelegram(context, num) }
     val openSignal = { num: String -> SocialUtils.openSignal(context, num) }
 
+    val shareContactText = stringResource(R.string.contact_share_text, displayName, displayPhone)
     val shareContact = {
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"
-            putExtra(Intent.EXTRA_TEXT, "Name: $displayName\nPhone: $displayPhone")
+            putExtra(Intent.EXTRA_TEXT, shareContactText)
         }
-        context.startActivity(Intent.createChooser(intent, "Share Contact"))
+        context.startActivity(Intent.createChooser(intent, shareContactLabel))
     }
 
     val onNumberActionClick = { action: (String) -> Unit, title: String ->
@@ -190,22 +195,23 @@ fun ContactDetailsScreen(
                     navigator.navigateUp()
                 }
             },
-            title = "Delete Contact?",
-            message = "Are you sure you want to delete this contact? This action cannot be undone.",
-            confirmLabel = "Delete",
+            title = stringResource(R.string.contact_delete_dialog_title),
+            message = stringResource(R.string.contact_delete_dialog_message),
+            confirmLabel = stringResource(R.string.action_delete),
             icon = Icons.Default.Delete,
             isDestructive = true
         )
     }
 
     if (showNumberSelectionDialog && fullContact != null) {
+        val mobileLabel = stringResource(R.string.label_mobile)
         RivoSelectionDialog(
             onDismissRequest = { showNumberSelectionDialog = false },
             title = selectionTitle,
             items = fullContact!!.phoneNumbers,
             itemLabel = { formatPhoneNumber(it) },
             onItemSelected = { pendingSocialAction?.invoke(it) },
-            itemSupporting = { "Mobile" },
+            itemSupporting = { mobileLabel },
             icon = Icons.Default.Phone,
             itemIcon = { if (areNumbersEqual(favoriteNumber, it)) Icons.Default.Star else Icons.Default.Phone },
             isSelected = { areNumbersEqual(favoriteNumber, it) }
@@ -215,14 +221,14 @@ fun ContactDetailsScreen(
     if (showQrDialog) {
         RivoDialog(
             onDismissRequest = { showQrDialog = false },
-            title = "Contact QR",
+            title = stringResource(R.string.contact_details_qr_title),
             icon = Icons.Default.QrCode,
             confirmButton = {
                 Button(
                     onClick = { showQrDialog = false },
                     shape = RoundedCornerShape(12.dp)
                 ) {
-                    Text("Close")
+                    Text(stringResource(R.string.action_close))
                 }
             }
         ) {
@@ -238,7 +244,7 @@ fun ContactDetailsScreen(
                 qrBitmap?.let {
                     Image(
                         bitmap = it.asImageBitmap(),
-                        contentDescription = "QR Code",
+                        contentDescription = stringResource(R.string.contact_details_qr_content_desc),
                         modifier = Modifier
                             .size(240.dp)
                             .background(Color.White, RoundedCornerShape(12.dp))
@@ -268,7 +274,7 @@ fun ContactDetailsScreen(
                 title = { },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
                 actions = {
@@ -282,7 +288,7 @@ fun ContactDetailsScreen(
                         }) {
                             Icon(
                                 if (isFavorite) Icons.Default.Star else Icons.Default.StarBorder,
-                                contentDescription = "Favorite",
+                                contentDescription = stringResource(R.string.content_desc_favorite),
                                 tint = if (isFavorite) MaterialTheme.colorScheme.primary else LocalContentColor.current
                             )
                         }
@@ -291,13 +297,13 @@ fun ContactDetailsScreen(
                                 navigator.navigate(ContactEditScreenDestination(contactId = it.id))
                             }
                         }) {
-                            Icon(Icons.Default.Edit, contentDescription = "Edit")
+                            Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.action_edit))
                         }
-                    } else if (phoneNumber != null && phoneNumber != "Unknown") {
+                    } else if (phoneNumber != null && phoneNumber != unknownLabel) {
                         IconButton(onClick = {
                             navigator.navigate(ContactEditScreenDestination(initialPhone = phoneNumber))
                         }) {
-                            Icon(Icons.Default.PersonAdd, contentDescription = "Add Contact")
+                            Icon(Icons.Default.PersonAdd, contentDescription = stringResource(R.string.action_add_contact))
                         }
                     }
                 }
@@ -351,7 +357,7 @@ fun ContactDetailsScreen(
                         ) {
                             RivoExpressiveButton(
                                 icon = Icons.Default.Call,
-                                label = "Call",
+                                label = stringResource(R.string.contact_details_call),
                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                 onClick = {
                                     callLauncher.dial(if (fullContact == null) displayPhone else "", fullContact)
@@ -359,7 +365,7 @@ fun ContactDetailsScreen(
                             )
                             RivoExpressiveButton(
                                 icon = Icons.AutoMirrored.Filled.Message,
-                                label = "Message",
+                                label = stringResource(R.string.action_message),
                                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                                 onClick = {
                                     messageLauncher.sendMessage(if (fullContact == null) displayPhone else "", fullContact)
@@ -367,7 +373,7 @@ fun ContactDetailsScreen(
                             )
                             RivoExpressiveButton(
                                 icon = Icons.Default.VideoCall,
-                                label = "Video",
+                                label = stringResource(R.string.contact_details_video),
                                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                                 onClick = {
                                     videoLauncher.startVideoCall(displayPhone, fullContact)
@@ -376,7 +382,7 @@ fun ContactDetailsScreen(
                             val hasEmails = fullContact?.emails?.isNotEmpty() == true
                             RivoExpressiveButton(
                                 icon = Icons.Default.Email,
-                                label = "Email",
+                                label = stringResource(R.string.label_email),
                                 containerColor = if (hasEmails) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceVariant,
                                 contentColor = if (hasEmails) LocalContentColor.current else LocalContentColor.current.copy(alpha = 0.38f),
                                 onClick = {
@@ -390,7 +396,10 @@ fun ContactDetailsScreen(
 
                     item {
                         val lastUsed = fullContact?.id?.let { prefs.getLastUsedNumber(it) }
-                        RivoExpressiveCard(title = "Contact Info", icon = Icons.Default.Info) {
+                        val mobileLabel = stringResource(R.string.label_mobile)
+                        val bulletFavorite = stringResource(R.string.contact_bullet_favorite)
+                        val bulletRecent = stringResource(R.string.contact_bullet_recent)
+                        RivoExpressiveCard(title = stringResource(R.string.contact_details_info_title), icon = Icons.Default.Info) {
                             if (fullContact != null) {
                                 val uniquePhoneNumbers = remember(fullContact) {
                                     deduplicateNumbers(fullContact!!.phoneNumbers)
@@ -398,16 +407,16 @@ fun ContactDetailsScreen(
                                 uniquePhoneNumbers.forEachIndexed { index, number ->
                                     val isRecent = lastUsed != null && areNumbersEqual(lastUsed, number)
                                     val isFav = areNumbersEqual(favoriteNumber, number)
-                                    
+
                                     var showMenu by remember { mutableStateOf(false) }
-                                    
+
                                     Box {
                                         RivoListItem(
                                             headline = formatPhoneNumber(number),
                                             supporting = buildString {
-                                                append("Mobile")
-                                                if (isFav) append(" • Favorite")
-                                                if (isRecent) append(" • Recent")
+                                                append(mobileLabel)
+                                                if (isFav) append(bulletFavorite)
+                                                if (isRecent) append(bulletRecent)
                                             },
                                             leadingIcon = Icons.Default.Phone,
                                             trailingIcon = if (isFav) Icons.Default.Star else if (isRecent) Icons.Default.History else null,
@@ -420,7 +429,7 @@ fun ContactDetailsScreen(
                                             onDismissRequest = { showMenu = false }
                                         ) {
                                             DropdownMenuItem(
-                                                text = { Text(if (isFav) "Clear Favorite" else "Set as Favorite") },
+                                                text = { Text(if (isFav) stringResource(R.string.contact_clear_favorite) else stringResource(R.string.contact_set_as_favorite)) },
                                                 onClick = {
                                                     showMenu = false
                                                     if (isFav) {
@@ -435,7 +444,7 @@ fun ContactDetailsScreen(
                                                 leadingIcon = { Icon(if (isFav) Icons.Default.StarOutline else Icons.Default.Star, null) }
                                             )
                                             DropdownMenuItem(
-                                                text = { Text("Copy to Clipboard") },
+                                                text = { Text(stringResource(R.string.contact_copy_to_clipboard)) },
                                                 onClick = {
                                                     showMenu = false
                                                     clipboardManager.setText(AnnotatedString(number))
@@ -455,7 +464,7 @@ fun ContactDetailsScreen(
                                     Box {
                                         RivoListItem(
                                             headline = email,
-                                            supporting = if (isFav) "Email • Favorite" else "Email",
+                                            supporting = if (isFav) stringResource(R.string.label_email) + stringResource(R.string.contact_bullet_favorite) else stringResource(R.string.label_email),
                                             leadingIcon = Icons.Default.Email,
                                             onClick = { emailLauncher.sendEmail(email, fullContact) },
                                             onLongClick = { showMenu = true }
@@ -466,7 +475,7 @@ fun ContactDetailsScreen(
                                             onDismissRequest = { showMenu = false }
                                         ) {
                                             DropdownMenuItem(
-                                                text = { Text(if (isFav) "Clear Default" else "Set as Default") },
+                                                text = { Text(if (isFav) stringResource(R.string.contact_clear_default) else stringResource(R.string.contact_set_as_default)) },
                                                 onClick = {
                                                     showMenu = false
                                                     if (isFav) {
@@ -480,7 +489,7 @@ fun ContactDetailsScreen(
                                                 leadingIcon = { Icon(if (isFav) Icons.Default.StarOutline else Icons.Default.Star, null) }
                                             )
                                             DropdownMenuItem(
-                                                text = { Text("Copy to Clipboard") },
+                                                text = { Text(stringResource(R.string.contact_copy_to_clipboard)) },
                                                 onClick = {
                                                     showMenu = false
                                                     clipboardManager.setText(AnnotatedString(email))
@@ -493,12 +502,12 @@ fun ContactDetailsScreen(
                                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                                     }
                                 }
-                            } else if (phoneNumber != null && phoneNumber != "Unknown") {
+                            } else if (phoneNumber != null && phoneNumber != unknownLabel) {
                                 var showMenu by remember { mutableStateOf(false) }
                                 Box {
                                     RivoListItem(
                                         headline = formatPhoneNumber(phoneNumber),
-                                        supporting = "Unknown Number",
+                                        supporting = stringResource(R.string.label_unknown_number),
                                         leadingIcon = Icons.Default.Phone,
                                         onClick = { callLauncher.dial(phoneNumber, null) },
                                         onLongClick = { showMenu = true }
@@ -509,7 +518,7 @@ fun ContactDetailsScreen(
                                         onDismissRequest = { showMenu = false }
                                     ) {
                                         DropdownMenuItem(
-                                            text = { Text("Add to Contacts") },
+                                            text = { Text(stringResource(R.string.contact_add_to_contacts)) },
                                             onClick = {
                                                 showMenu = false
                                                 navigator.navigate(
@@ -521,7 +530,7 @@ fun ContactDetailsScreen(
                                             leadingIcon = { Icon(Icons.Default.PersonAdd, null) }
                                         )
                                         DropdownMenuItem(
-                                            text = { Text("Copy to Clipboard") },
+                                            text = { Text(stringResource(R.string.contact_copy_to_clipboard)) },
                                             onClick = {
                                                 showMenu = false
                                                 clipboardManager.setText(AnnotatedString(phoneNumber))
@@ -536,12 +545,12 @@ fun ContactDetailsScreen(
 
                     if (fullContact != null && (fullContact!!.events.isNotEmpty() || fullContact!!.addresses.isNotEmpty())) {
                         item {
-                            RivoExpressiveCard(title = "Events & More", icon = Icons.Default.Event) {
+                            RivoExpressiveCard(title = stringResource(R.string.contact_events_title), icon = Icons.Default.Event) {
                                 fullContact!!.events.forEachIndexed { index, event ->
                                     val isBirthday = event.type == ContactsContract.CommonDataKinds.Event.TYPE_BIRTHDAY
                                     RivoListItem(
                                         headline = event.date,
-                                        supporting = event.label ?: if (isBirthday) "Birthday" else "Event",
+                                        supporting = event.label ?: if (isBirthday) stringResource(R.string.contact_event_birthday) else stringResource(R.string.contact_event_generic),
                                         leadingIcon = if (isBirthday) Icons.Outlined.Cake else Icons.Outlined.Event,
                                         onClick = { }
                                     )
@@ -552,7 +561,7 @@ fun ContactDetailsScreen(
                                 fullContact!!.addresses.forEachIndexed { index, address ->
                                     RivoListItem(
                                         headline = address,
-                                        supporting = "Address",
+                                        supporting = stringResource(R.string.label_address),
                                         leadingIcon = Icons.Default.LocationOn,
                                         onClick = {
                                             val intent = Intent(Intent.ACTION_VIEW, Uri.parse("geo:0,0?q=$address"))
@@ -570,7 +579,7 @@ fun ContactDetailsScreen(
                     if (fullContact?.notes?.isNotBlank() == true) {
                         item {
                             var showNotesMenu by remember { mutableStateOf(false) }
-                            RivoExpressiveCard(title = "Notes", icon = Icons.AutoMirrored.Filled.Notes) {
+                            RivoExpressiveCard(title = stringResource(R.string.label_notes), icon = Icons.AutoMirrored.Filled.Notes) {
                                 Box {
                                     Text(
                                         text = fullContact!!.notes!!,
@@ -589,7 +598,7 @@ fun ContactDetailsScreen(
                                         onDismissRequest = { showNotesMenu = false }
                                     ) {
                                         DropdownMenuItem(
-                                            text = { Text("Copy to Clipboard") },
+                                            text = { Text(stringResource(R.string.contact_copy_to_clipboard)) },
                                             onClick = {
                                                 showNotesMenu = false
                                                 clipboardManager.setText(AnnotatedString(fullContact!!.notes!!))
@@ -604,7 +613,7 @@ fun ContactDetailsScreen(
 
                     if (contactLogs.isNotEmpty()) {
                         item {
-                            RivoExpressiveCard(title = "Recent Activity", icon = Icons.Default.History) {
+                            RivoExpressiveCard(title = stringResource(R.string.contact_recent_activity_title), icon = Icons.Default.History) {
                                 Column(modifier = Modifier.animateContentSize()) {
                                     contactLogs.take(3).forEachIndexed { index, log ->
                                         CallLogTileSimple(
@@ -629,7 +638,7 @@ fun ContactDetailsScreen(
                                             },
                                             modifier = Modifier.fillMaxWidth()
                                         ) {
-                                            Text("Show full history")
+                                            Text(stringResource(R.string.contact_show_full_history))
                                         }
                                     }
                                 }
@@ -638,34 +647,37 @@ fun ContactDetailsScreen(
                     }
 
                     item {
-                        RivoExpressiveCard(title = "Social Apps", icon = Icons.AutoMirrored.Filled.Chat) {
+                        val whatsAppLabel = stringResource(R.string.brand_whatsapp)
+                        val telegramLabel = stringResource(R.string.brand_telegram)
+                        val signalLabel = stringResource(R.string.brand_signal)
+                        RivoExpressiveCard(title = stringResource(R.string.label_social_apps), icon = Icons.AutoMirrored.Filled.Chat) {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(8.dp),
                                 horizontalArrangement = Arrangement.SpaceEvenly
                             ) {
                                 RivoExpressiveButton(
                                     painter = rememberAsyncImagePainter("file:///android_asset/icons/whatsapp.png"),
-                                    label = "WhatsApp",
+                                    label = whatsAppLabel,
                                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                                     size = 52.dp,
                                     iconSize = 32.dp,
-                                    onClick = { onNumberActionClick(openWhatsApp, "WhatsApp") }
+                                    onClick = { onNumberActionClick(openWhatsApp, whatsAppLabel) }
                                 )
                                 RivoExpressiveButton(
                                     painter = rememberAsyncImagePainter("file:///android_asset/icons/telegram.png"),
-                                    label = "Telegram",
+                                    label = telegramLabel,
                                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                                     size = 52.dp,
                                     iconSize = 32.dp,
-                                    onClick = { onNumberActionClick(openTelegram, "Telegram") }
+                                    onClick = { onNumberActionClick(openTelegram, telegramLabel) }
                                 )
                                 RivoExpressiveButton(
                                     painter = rememberAsyncImagePainter("file:///android_asset/icons/signal.png"),
-                                    label = "Signal",
+                                    label = signalLabel,
                                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
                                     size = 52.dp,
                                     iconSize = 32.dp,
-                                    onClick = { onNumberActionClick(openSignal, "Signal") }
+                                    onClick = { onNumberActionClick(openSignal, signalLabel) }
                                 )
                             }
                         }
@@ -673,19 +685,22 @@ fun ContactDetailsScreen(
 
                     if (fullContact != null) {
                         item {
-                            RivoExpressiveCard(title = "Contact Settings", icon = Icons.Default.Settings) {
+                            val defaultRingtoneLabel = stringResource(R.string.ringtone_default)
+                            val customRingtoneLabel = stringResource(R.string.ringtone_custom)
+                            val selectRingtoneLabel = stringResource(R.string.contact_select_ringtone)
+                            RivoExpressiveCard(title = stringResource(R.string.contact_settings_title), icon = Icons.Default.Settings) {
                                 val currentRingtone = fullContact!!.customRingtone?.let {
-                                    RingtoneManager.getRingtone(context, Uri.parse(it))?.getTitle(context) ?: "Custom"
-                                } ?: "Default"
+                                    RingtoneManager.getRingtone(context, Uri.parse(it))?.getTitle(context) ?: customRingtoneLabel
+                                } ?: defaultRingtoneLabel
 
                                 RivoListItem(
-                                    headline = "Custom Ringtone",
+                                    headline = stringResource(R.string.contact_custom_ringtone),
                                     supporting = currentRingtone,
                                     leadingIcon = Icons.Default.MusicNote,
                                     onClick = {
                                         val intent = Intent(RingtoneManager.ACTION_RINGTONE_PICKER).apply {
                                             putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_RINGTONE)
-                                            putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "Select Ringtone")
+                                            putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, selectRingtoneLabel)
                                             putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, fullContact!!.customRingtone?.let { Uri.parse(it) })
                                         }
                                         ringtonePickerLauncher.launch(intent)
@@ -693,22 +708,22 @@ fun ContactDetailsScreen(
                                 )
                                 RivoDivider(Modifier.padding(horizontal = 16.dp))
                                 RivoListItem(
-                                    headline = "Share Contact",
-                                    supporting = "Send contact details to others",
+                                    headline = shareContactLabel,
+                                    supporting = stringResource(R.string.contact_share_description),
                                     leadingIcon = Icons.Default.Share,
                                     onClick = shareContact
                                 )
                                 RivoDivider(Modifier.padding(horizontal = 16.dp))
                                 RivoListItem(
-                                    headline = "QR Code",
-                                    supporting = "Show contact QR code",
+                                    headline = stringResource(R.string.contact_qr_code),
+                                    supporting = stringResource(R.string.contact_qr_code_description),
                                     leadingIcon = Icons.Outlined.QrCode2,
                                     onClick = { showQrDialog = true }
                                 )
                                 RivoDivider(Modifier.padding(horizontal = 16.dp))
                                 RivoListItem(
-                                    headline = if (fullContact!!.isPrivate) "Move to Public Storage" else "Move to Private Storage",
-                                    supporting = if (fullContact!!.isPrivate) "Make visible to other apps" else "Hide from other apps",
+                                    headline = if (fullContact!!.isPrivate) stringResource(R.string.contact_move_to_public_storage) else stringResource(R.string.contact_move_to_private_storage),
+                                    supporting = if (fullContact!!.isPrivate) stringResource(R.string.contact_visible_to_other_apps) else stringResource(R.string.contact_hidden_from_other_apps),
                                     leadingIcon = if (fullContact!!.isPrivate) Icons.Default.LockOpen else Icons.Default.Lock,
                                     onClick = {
                                         if (fullContact!!.isPrivate) {
@@ -721,8 +736,8 @@ fun ContactDetailsScreen(
                                 )
                                 RivoDivider(Modifier.padding(horizontal = 16.dp))
                                 RivoListItem(
-                                    headline = "Delete",
-                                    supporting = "Remove this contact from device",
+                                    headline = stringResource(R.string.action_delete),
+                                    supporting = stringResource(R.string.contact_remove_from_device),
                                     leadingIcon = Icons.Default.Delete,
                                     onClick = { showDeleteDialog = true }
                                 )

--- a/app/src/main/java/com/grinch/rivo4/view/screen/ContactEdit.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/ContactEdit.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.ContactUtils
 import com.grinch.rivo4.controller.util.deduplicateNumbers
@@ -126,13 +128,13 @@ fun ContactEditScreen(
             TopAppBar(
                 title = {
                     Text(
-                        if (contactId == null || contactId == "0") "Create Contact" else "Edit Contact",
+                        if (contactId == null || contactId == "0") stringResource(R.string.contact_create_title) else stringResource(R.string.contact_edit_title),
                         fontWeight = FontWeight.Bold
                     )
                 },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
                 actions = {
@@ -180,7 +182,7 @@ fun ContactEditScreen(
                         ) {
                             Icon(Icons.Default.Check, null)
                             Spacer(Modifier.width(8.dp))
-                            Text("Save")
+                            Text(stringResource(R.string.action_save))
                         }
                     }
                 },
@@ -200,9 +202,9 @@ fun ContactEditScreen(
                         navigator.navigateUp()
                     }
                 },
-                title = "Delete Contact?",
-                message = "Are you sure you want to delete this contact? This action cannot be undone.",
-                confirmLabel = "Delete",
+                title = stringResource(R.string.contact_delete_dialog_title),
+                message = stringResource(R.string.contact_delete_dialog_message),
+                confirmLabel = stringResource(R.string.action_delete),
                 icon = Icons.Default.Delete,
                 isDestructive = true
             )
@@ -260,7 +262,7 @@ fun ContactEditScreen(
             }
 
             item {
-                RivoSectionHeader(title = "Account")
+                RivoSectionHeader(title = stringResource(R.string.contact_edit_account_header))
                 RivoExpressiveCard {
                     var showPicker by remember { mutableStateOf(false) }
 
@@ -287,15 +289,15 @@ fun ContactEditScreen(
                             Spacer(Modifier.width(16.dp))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
-                                    text = "Save to Account",
+                                    text = stringResource(R.string.contact_edit_save_to_account),
                                     style = MaterialTheme.typography.labelMedium,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                                 Text(
                                     text = when {
-                                        isPrivate -> "Private Storage (App Only)"
+                                        isPrivate -> stringResource(R.string.contact_edit_private_storage)
                                         selectedAccount != null -> ContactUtils.getFriendlyAccountName(selectedAccount!!)
-                                        else -> "Local Memory"
+                                        else -> stringResource(R.string.label_local_memory)
                                     },
                                     style = MaterialTheme.typography.bodyLarge,
                                     fontWeight = FontWeight.Bold
@@ -308,11 +310,11 @@ fun ContactEditScreen(
                     if (showPicker) {
                         RivoDialog(
                             onDismissRequest = { showPicker = false },
-                            title = "Select Account",
+                            title = stringResource(R.string.contact_edit_select_account_title),
                             icon = Icons.Default.AccountBalance,
                             dismissButton = {
                                 TextButton(onClick = { showPicker = false }) {
-                                    Text("Cancel")
+                                    Text(stringResource(R.string.action_cancel))
                                 }
                             }
                         ) {
@@ -327,8 +329,8 @@ fun ContactEditScreen(
                                 modifier = Modifier.fillMaxWidth()
                             ) {
                                 ListItem(
-                                    headlineContent = { Text("Private Storage (App Only)") },
-                                    supportingContent = { Text("Not visible to other apps") },
+                                    headlineContent = { Text(stringResource(R.string.contact_edit_private_storage)) },
+                                    supportingContent = { Text(stringResource(R.string.contact_edit_private_storage_description)) },
                                     leadingContent = { Icon(Icons.Default.Lock, null) },
                                     colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                                 )
@@ -345,7 +347,7 @@ fun ContactEditScreen(
                                 modifier = Modifier.fillMaxWidth()
                             ) {
                                 ListItem(
-                                    headlineContent = { Text("Local Memory") },
+                                    headlineContent = { Text(stringResource(R.string.label_local_memory)) },
                                     leadingContent = { Icon(Icons.Default.CloudOff, null) },
                                     colors = ListItemDefaults.colors(containerColor = Color.Transparent)
                                 )
@@ -377,13 +379,13 @@ fun ContactEditScreen(
             }
 
             item {
-                RivoSectionHeader(title = "Identity")
+                RivoSectionHeader(title = stringResource(R.string.contact_edit_identity_header))
                 RivoExpressiveCard {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         OutlinedTextField(
                             value = name,
                             onValueChange = { name = it },
-                            label = { Text("Full Name") },
+                            label = { Text(stringResource(R.string.contact_edit_full_name)) },
                             modifier = Modifier.fillMaxWidth(),
                             shape = RoundedCornerShape(16.dp),
                             leadingIcon = { Icon(Icons.Default.Person, null) },
@@ -395,7 +397,7 @@ fun ContactEditScreen(
                         OutlinedTextField(
                             value = nickname,
                             onValueChange = { nickname = it },
-                            label = { Text("Nickname") },
+                            label = { Text(stringResource(R.string.contact_edit_nickname)) },
                             modifier = Modifier.fillMaxWidth(),
                             shape = RoundedCornerShape(16.dp),
                             leadingIcon = { Icon(Icons.AutoMirrored.Filled.Label, null) },
@@ -410,15 +412,17 @@ fun ContactEditScreen(
 
 
             item {
-                RivoSectionHeader(title = "Phone Numbers")
+                RivoSectionHeader(title = stringResource(R.string.contact_edit_phone_numbers_header))
                 RivoExpressiveCard {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        val phoneFieldLabel = stringResource(R.string.contact_edit_phone_field_label)
                         phoneNumbers.forEachIndexed { index, phone ->
                             EditField(
                                 value = phone,
                                 onValueChange = { phoneNumbers[index] = it },
-                                label = "Phone",
+                                label = phoneFieldLabel,
                                 icon = Icons.Default.Phone,
+                                keyboardType = KeyboardType.Phone,
                                 onDelete = {
                                     if (phoneNumbers.size > 1) {
                                         phoneNumbers.removeAt(index)
@@ -434,7 +438,7 @@ fun ContactEditScreen(
                         ) {
                             Icon(Icons.Default.Add, null)
                             Spacer(Modifier.width(8.dp))
-                            Text("Add Phone")
+                            Text(stringResource(R.string.contact_edit_add_phone))
                         }
                     }
                 }
@@ -442,15 +446,17 @@ fun ContactEditScreen(
 
 
             item {
-                RivoSectionHeader(title = "Emails")
+                RivoSectionHeader(title = stringResource(R.string.contact_edit_emails_header))
                 RivoExpressiveCard {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        val emailFieldLabel = stringResource(R.string.label_email)
                         emails.forEachIndexed { index, email ->
                             EditField(
                                 value = email,
                                 onValueChange = { emails[index] = it },
-                                label = "Email",
+                                label = emailFieldLabel,
                                 icon = Icons.Default.Email,
+                                keyboardType = KeyboardType.Email,
                                 onDelete = {
                                     if (emails.size > 1) {
                                         emails.removeAt(index)
@@ -466,7 +472,7 @@ fun ContactEditScreen(
                         ) {
                             Icon(Icons.Default.Add, null)
                             Spacer(Modifier.width(8.dp))
-                            Text("Add Email")
+                            Text(stringResource(R.string.contact_edit_add_email))
                         }
                     }
                 }
@@ -474,14 +480,15 @@ fun ContactEditScreen(
 
 
             item {
-                RivoSectionHeader(title = "Address")
+                RivoSectionHeader(title = stringResource(R.string.contact_edit_address_header))
                 RivoExpressiveCard {
                     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        val addressFieldLabel = stringResource(R.string.label_address)
                         addresses.forEachIndexed { index, address ->
                             EditField(
                                 value = address,
                                 onValueChange = { addresses[index] = it },
-                                label = "Address",
+                                label = addressFieldLabel,
                                 icon = Icons.Default.LocationOn,
                                 onDelete = {
                                     if (addresses.size > 1) {
@@ -498,19 +505,19 @@ fun ContactEditScreen(
                         ) {
                             Icon(Icons.Default.Add, null)
                             Spacer(Modifier.width(8.dp))
-                            Text("Add Address")
+                            Text(stringResource(R.string.contact_edit_add_address))
                         }
                     }
                 }
             }
 
             item {
-                RivoSectionHeader(title = "Notes")
+                RivoSectionHeader(title = stringResource(R.string.contact_edit_notes_header))
                 RivoExpressiveCard {
                     OutlinedTextField(
                         value = notes,
                         onValueChange = { notes = it },
-                        label = { Text("Notes") },
+                        label = { Text(stringResource(R.string.label_notes)) },
                         modifier = Modifier.fillMaxWidth(),
                         shape = RoundedCornerShape(16.dp),
                         leadingIcon = { Icon(Icons.AutoMirrored.Filled.Notes, null) },
@@ -534,7 +541,8 @@ fun EditField(
     onValueChange: (String) -> Unit,
     label: String,
     icon: ImageVector,
-    onDelete: () -> Unit
+    onDelete: () -> Unit,
+    keyboardType: KeyboardType = KeyboardType.Text
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -547,11 +555,7 @@ fun EditField(
             modifier = Modifier.weight(1f),
             shape = RoundedCornerShape(16.dp),
             leadingIcon = { Icon(icon, null, tint = MaterialTheme.colorScheme.primary) },
-            keyboardOptions = when (label) {
-                "Phone" -> KeyboardOptions(keyboardType = KeyboardType.Phone)
-                "Email" -> KeyboardOptions(keyboardType = KeyboardType.Email)
-                else -> KeyboardOptions.Default
-            },
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
             colors = OutlinedTextFieldDefaults.colors(
                 unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant,
                 focusedBorderColor = MaterialTheme.colorScheme.primary

--- a/app/src/main/java/com/grinch/rivo4/view/screen/DefaultDialer.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/DefaultDialer.kt
@@ -20,10 +20,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.controller.util.getDefaultDialerIntent
 import com.grinch.rivo4.controller.util.isAlreadyDefaultDialer
@@ -115,7 +117,7 @@ fun DefaultDialerScreen(navController: NavController, navigator: DestinationsNav
                 Spacer(modifier = Modifier.height(40.dp))
 
                 Text(
-                    text = "Make Rivo your official dialer",
+                    text = stringResource(R.string.default_dialer_headline),
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
@@ -125,7 +127,7 @@ fun DefaultDialerScreen(navController: NavController, navigator: DestinationsNav
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Text(
-                    text = "To make and receive calls, manage your call history, and experience spam protection, Rivo needs to be set as your default phone app.",
+                    text = stringResource(R.string.default_dialer_description),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -142,7 +144,7 @@ fun DefaultDialerScreen(navController: NavController, navigator: DestinationsNav
                             .fillMaxWidth()
                     ) {
                         Text(
-                            text = "Rivo cannot function without this permission. Please try again.",
+                            text = stringResource(R.string.default_dialer_denied_message),
                             color = MaterialTheme.colorScheme.onErrorContainer,
                             style = MaterialTheme.typography.bodyMedium,
                             modifier = Modifier.padding(16.dp),
@@ -168,7 +170,7 @@ fun DefaultDialerScreen(navController: NavController, navigator: DestinationsNav
                     shape = MaterialTheme.shapes.extraLarge
                 ) {
                     Text(
-                        text = "Set as default",
+                        text = stringResource(R.string.default_dialer_set_as_default),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.SemiBold
                     )

--- a/app/src/main/java/com/grinch/rivo4/view/screen/Dialpad.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/Dialpad.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.InterceptPlatformTextInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -54,6 +55,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.controller.util.SocialUtils
@@ -197,16 +199,16 @@ fun DialPadScreen(
         containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             TopAppBar(
-                title = { Text("Dialpad", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.dialpad_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
                 actions = {
                     if (number.isNotEmpty()) {
                         IconButton(onClick = { showSocialDialog = true }) {
-                            Icon(Icons.AutoMirrored.Filled.Chat, "Social Apps")
+                            Icon(Icons.AutoMirrored.Filled.Chat, stringResource(R.string.label_social_apps))
                         }
                     }
                 }
@@ -242,12 +244,12 @@ fun DialPadScreen(
                     }
                     Spacer(modifier = Modifier.height(12.dp))
                     Text(
-                        "Start Dialing",
+                        stringResource(R.string.dialpad_start_dialing),
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold
                     )
                     Text(
-                        "Enter a name or number to start",
+                        stringResource(R.string.dialpad_start_hint),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -310,7 +312,7 @@ fun DialPadScreen(
                                         ) {
                                             Icon(
                                                 Icons.Rounded.Call,
-                                                contentDescription = "Call ${contact.name}",
+                                                contentDescription = stringResource(R.string.content_desc_call_named, contact.name),
                                                 tint = MaterialTheme.colorScheme.primary
                                             )
                                         }
@@ -463,7 +465,7 @@ fun DialPadScreen(
                                         )
                                     },
                                     icon = Icons.Default.PersonAdd,
-                                    contentDescription = "Add Contact",
+                                    contentDescription = stringResource(R.string.action_add_contact),
                                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                                 )
                             }
@@ -472,7 +474,7 @@ fun DialPadScreen(
                             DialerActionExpressive(
                                 onClick = { performCall(number, null) },
                                 icon = Icons.Default.Call,
-                                contentDescription = "Call",
+                                contentDescription = stringResource(R.string.action_call),
                                 containerColor = Color(0xFF4CAF50),
                                 contentColor = Color.White,
                                 modifier = Modifier.width(100.dp).height(72.dp),
@@ -504,7 +506,7 @@ fun DialPadScreen(
                                         }
                                     },
                                     icon = Icons.AutoMirrored.Filled.Backspace,
-                                    contentDescription = "Backspace",
+                                    contentDescription = stringResource(R.string.content_desc_backspace),
                                     containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                                 )
                             }
@@ -518,7 +520,7 @@ fun DialPadScreen(
     if (showSocialDialog) {
         RivoDialog(
             onDismissRequest = { showSocialDialog = false },
-            title = "Connect via Social",
+            title = stringResource(R.string.dialpad_connect_via_social),
             icon = Icons.AutoMirrored.Filled.Chat,
             dismissButton = {
                 TextButton(
@@ -526,7 +528,7 @@ fun DialPadScreen(
                     modifier = Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(20.dp)
                 ) {
-                    Text("Close")
+                    Text(stringResource(R.string.action_close))
                 }
             }
         ) {
@@ -537,7 +539,7 @@ fun DialPadScreen(
             ) {
                 RivoExpressiveButton(
                     painter = rememberAsyncImagePainter("file:///android_asset/icons/whatsapp.png"),
-                    label = "WhatsApp",
+                    label = stringResource(R.string.brand_whatsapp),
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                     size = 52.dp,
                     iconSize = 32.dp,
@@ -548,7 +550,7 @@ fun DialPadScreen(
                 )
                 RivoExpressiveButton(
                     painter = rememberAsyncImagePainter("file:///android_asset/icons/telegram.png"),
-                    label = "Telegram",
+                    label = stringResource(R.string.brand_telegram),
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                     size = 52.dp,
                     iconSize = 32.dp,
@@ -559,7 +561,7 @@ fun DialPadScreen(
                 )
                 RivoExpressiveButton(
                     painter = rememberAsyncImagePainter("file:///android_asset/icons/signal.png"),
-                    label = "Signal",
+                    label = stringResource(R.string.brand_signal),
                     containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
                     size = 52.dp,
                     iconSize = 32.dp,

--- a/app/src/main/java/com/grinch/rivo4/view/screen/Recents.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/Recents.kt
@@ -19,11 +19,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.CallLogViewModel
 import com.grinch.rivo4.controller.util.formatDateHeader
 import com.grinch.rivo4.view.components.*
@@ -41,6 +43,7 @@ import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.modal.data.CallLogFilter
 import com.grinch.rivo4.modal.data.CallLogEntry
 import com.grinch.rivo4.modal.data.Contact
+import com.grinch.rivo4.modal.data.displayLabel
 import com.grinch.rivo4.view.screen.transitions.NoTransitions
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinActivityViewModel
@@ -88,10 +91,10 @@ fun RecentScreen(navController: NavController, navigator: DestinationsNavigator)
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             items(CallLogFilter.entries) { filter ->
-                                RivoFilterChip(filter.name, selectedFilter == filter, {
+                                RivoFilterChip(filter.displayLabel(), selectedFilter == filter, {
                                         _ ->
                                     viewModel.setFilter(filter)
-                                })
+                                }, isAllFilter = filter == CallLogFilter.All)
                             }
                         }
                     }
@@ -121,7 +124,7 @@ fun RecentScreen(navController: NavController, navigator: DestinationsNavigator)
                     shape = RoundedCornerShape(20.dp),
                     elevation = FloatingActionButtonDefaults.elevation(0.dp)
                 ) {
-                    Icon(Icons.Default.Dialpad, "Dialpad")
+                    Icon(Icons.Default.Dialpad, stringResource(R.string.content_desc_dialpad))
                 }
             }
         },
@@ -273,7 +276,7 @@ fun CallLogFullContent(
         }
 
         val groupedLogs = remember(filteredLogs) {
-            filteredLogs.groupBy { formatDateHeader(it.date) }
+            filteredLogs.groupBy { formatDateHeader(context, it.date) }
         }
 
         val pullToRefreshState = rememberPullToRefreshState()
@@ -309,14 +312,14 @@ fun CallLogFullContent(
                         if (favorites.isNotEmpty() && selectedFilter == CallLogFilter.All) {
                             item {
                                 RivoSectionHeader(
-                                    title = "Favorites",
+                                    title = stringResource(R.string.recents_favorites),
                                     trailingContent = {
                                         TextButton(
                                             onClick = { isEditingFavorites = !isEditingFavorites },
                                             modifier = Modifier.padding(end = 8.dp)
                                         ) {
                                             Text(
-                                                text = if (isEditingFavorites) "Done" else "Edit",
+                                                text = if (isEditingFavorites) stringResource(R.string.action_done) else stringResource(R.string.action_edit),
                                                 style = MaterialTheme.typography.labelLarge,
                                                 fontWeight = FontWeight.Bold,
                                                 color = MaterialTheme.colorScheme.primary
@@ -393,8 +396,8 @@ fun CallLogFullContent(
     } else {
         PermissionDeniedView(
             icon = Icons.Default.Call,
-            title = "Call History",
-            description = "Rivo needs access to your call logs to show your recent activity and missed calls.",
+            title = stringResource(R.string.recents_permission_title),
+            description = stringResource(R.string.recents_permission_description),
             onGrantClick = onRequestPermission
         )
     }
@@ -423,12 +426,12 @@ fun EmptyCallLogsState() {
         }
         Spacer(modifier = Modifier.height(24.dp))
         Text(
-            text = "Your call log is empty",
+            text = stringResource(R.string.recents_empty_call_log),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = "Try clearing your filters or add a new contact.",
+            text = stringResource(R.string.empty_state_try_clearing_filters),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,

--- a/app/src/main/java/com/grinch/rivo4/view/screen/Search.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/Search.kt
@@ -20,12 +20,14 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.controller.util.makeCall
@@ -90,8 +92,8 @@ fun ContactSearchContent(
     if (!isGranted) {
         PermissionDeniedView(
             icon = Icons.Default.Person,
-            title = "Contacts permission required",
-            description = "To search your contacts and identify incoming calls, Rivo needs access to your contacts.",
+            title = stringResource(R.string.search_contacts_permission_title),
+            description = stringResource(R.string.search_contacts_permission_description),
             onGrantClick = onRequestPermission
         )
         return
@@ -162,16 +164,16 @@ fun ContactSearchContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .focusRequester(focusRequester),
-                placeholder = { Text("Search contacts") },
+                placeholder = { Text(stringResource(R.string.search_contacts_placeholder)) },
                 leadingIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
                 trailingIcon = {
                     if (query.isNotEmpty()) {
                         IconButton(onClick = { query = "" }) {
-                            Icon(Icons.Default.Close, contentDescription = "Clear")
+                            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.action_clear))
                         }
                     }
                 },
@@ -223,12 +225,12 @@ fun ContactSearchContent(
                             }
                             Spacer(Modifier.height(24.dp))
                             Text(
-                                "Search Contacts",
+                                stringResource(R.string.search_contacts_title),
                                 style = MaterialTheme.typography.headlineSmall,
                                 fontWeight = FontWeight.Bold
                             )
                             Text(
-                                "Type a name or number to start searching",
+                                stringResource(R.string.search_type_to_start),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 textAlign = androidx.compose.ui.text.style.TextAlign.Center
@@ -239,12 +241,12 @@ fun ContactSearchContent(
                         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 Text(
-                                    "No results found",
+                                    stringResource(R.string.search_no_results_title),
                                     style = MaterialTheme.typography.titleLarge,
                                     fontWeight = FontWeight.Bold
                                 )
                                 Text(
-                                    "Try a different name or number",
+                                    stringResource(R.string.search_no_results_hint),
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }
@@ -257,7 +259,7 @@ fun ContactSearchContent(
                             contentPadding = PaddingValues(bottom = 100.dp)
                         ) {
                             item {
-                                RivoSectionHeader(title = "Search Results", modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                                RivoSectionHeader(title = stringResource(R.string.search_results_header), modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
                             }
 
                             itemsIndexed(filteredContacts) { index, contact ->

--- a/app/src/main/java/com/grinch/rivo4/view/screen/onboarding/MorphingOnboardingScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/onboarding/MorphingOnboardingScreen.kt
@@ -36,14 +36,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 
 data class MorphingPage(
     val icon: ImageVector,
-    val title: String,
-    val description: String,
+    @androidx.annotation.StringRes val titleRes: Int,
+    @androidx.annotation.StringRes val descriptionRes: Int,
     val shapeCornerPercent: Int,
     val rotation: Float,
     val scale: Float
@@ -52,24 +54,24 @@ data class MorphingPage(
 private val pages = listOf(
     MorphingPage(
         icon = Icons.Default.Palette,
-        title = "Expressive Design",
-        description = "Experience a modern interface powered by Material 3 and smooth Jetpack Compose animations.",
+        titleRes = R.string.onboarding_page1_title,
+        descriptionRes = R.string.onboarding_page1_description,
         shapeCornerPercent = 50,
         rotation = 0f,
         scale = 1f
     ),
     MorphingPage(
         icon = Icons.Default.Dialpad,
-        title = "Lightning-Fast Dialing",
-        description = "Find contacts in an instant with our intelligent T9 search and organized call history.",
+        titleRes = R.string.onboarding_page2_title,
+        descriptionRes = R.string.onboarding_page2_description,
         shapeCornerPercent = 30,
         rotation = 45f,
         scale = 1.2f
     ),
     MorphingPage(
         icon = Icons.Default.Security,
-        title = "Built for You",
-        description = "A fully open-source, proximity-aware calling experience designed for efficiency.",
+        titleRes = R.string.onboarding_page3_title,
+        descriptionRes = R.string.onboarding_page3_description,
         shapeCornerPercent = 10,
         rotation = 0f,
         scale = 1f
@@ -133,7 +135,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
                     .align(Alignment.TopEnd)
                     .padding(16.dp)
             ) {
-                Text("Skip")
+                Text(stringResource(R.string.onboarding_skip))
             }
 
             Column(
@@ -167,7 +169,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
 
                 // Title
                 Text(
-                    text = pages[currentPage].title,
+                    text = stringResource(pages[currentPage].titleRes),
                     style = MaterialTheme.typography.headlineMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onBackground,
@@ -178,7 +180,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
 
                 // Description
                 Text(
-                    text = pages[currentPage].description,
+                    text = stringResource(pages[currentPage].descriptionRes),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center,
@@ -227,7 +229,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
                 ) {
                     if (currentPage > 0) {
                         TextButton(onClick = { currentPage-- }) {
-                            Text("Back")
+                            Text(stringResource(R.string.action_back))
                         }
                     } else {
                         Spacer(modifier = Modifier.weight(1f))
@@ -244,7 +246,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
                         shape = RoundedCornerShape(cornerPercent.toInt().coerceIn(10, 50))
                     ) {
                         Text(
-                            text = if (currentPage == pages.size - 1) "Get Started" else "Next",
+                            text = if (currentPage == pages.size - 1) stringResource(R.string.onboarding_get_started) else stringResource(R.string.onboarding_next),
                             modifier = Modifier.padding(horizontal = 16.dp)
                         )
                     }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/About.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/About.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.grinch.rivo4.DISCORD_URL
@@ -45,10 +46,10 @@ fun AboutScreen(navigator: DestinationsNavigator) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("About", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.about_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -68,7 +69,7 @@ fun AboutScreen(navigator: DestinationsNavigator) {
             Box(contentAlignment = Alignment.Center) {
                 Image(
                     painter = painterResource(R.drawable.logo),
-                    contentDescription = "Rivo Logo",
+                    contentDescription = stringResource(R.string.about_logo_content_desc),
                     modifier = Modifier.size(64.dp)
                 )
             }
@@ -76,24 +77,24 @@ fun AboutScreen(navigator: DestinationsNavigator) {
             Spacer(modifier = Modifier.height(16.dp))
 
             Text(
-                text = "Rivo",
+                text = stringResource(R.string.about_app_display_name),
                 style = MaterialTheme.typography.headlineLarge,
                 fontWeight = FontWeight.Bold
             )
-            
+
             Spacer(modifier = Modifier.height(32.dp))
 
             RivoExpressiveCard(
                 containerColor = MaterialTheme.colorScheme.primaryContainer
             ) {
                 Text(
-                    "About the App",
+                    stringResource(R.string.about_app_card_title),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
                 Text(
-                    "Rivo is a modern dialer app that brings simplicity and elegance to calling. Designed with Material You, it adapts seamlessly to your theme.",
+                    stringResource(R.string.about_app_card_body),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
                 )
@@ -103,22 +104,22 @@ fun AboutScreen(navigator: DestinationsNavigator) {
 
             RivoExpressiveCard {
                 RivoListItem(
-                    headline = "Version",
+                    headline = stringResource(R.string.about_version),
                     supporting = appInfo.first,
                     leadingIcon = Icons.Outlined.Info,
                     onClick = { }
                 )
                 HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 RivoListItem(
-                    headline = "Build number",
+                    headline = stringResource(R.string.about_build_number),
                     supporting = appInfo.second.toString(),
                     leadingIcon = Icons.Default.Numbers,
                     onClick = { }
                 )
                 HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 RivoListItem(
-                    headline = "Contributors",
-                    supporting = "Meet the team behind the project",
+                    headline = stringResource(R.string.contributors_title),
+                    supporting = stringResource(R.string.about_contributors_supporting),
                     leadingIcon = Icons.Outlined.Groups,
                     onClick = { navigator.navigate(ContributorsScreenDestination) }
                 )
@@ -128,15 +129,15 @@ fun AboutScreen(navigator: DestinationsNavigator) {
 
             RivoExpressiveCard {
                 RivoListItem(
-                    headline = "Support Us on Patreon",
-                    supporting = "Help keep the project alive",
+                    headline = stringResource(R.string.about_patreon),
+                    supporting = stringResource(R.string.about_patreon_supporting),
                     leadingIcon = Icons.Default.Favorite,
                     onClick = { openLink(context, PATREON_URL) }
                 )
                 HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 RivoListItem(
-                    headline = "Discord Server",
-                    supporting = "Join the community",
+                    headline = stringResource(R.string.about_discord),
+                    supporting = stringResource(R.string.about_discord_supporting),
                     leadingIcon = Icons.Default.Chat,
                     onClick = { openLink(context, DISCORD_URL) }
                 )
@@ -146,15 +147,15 @@ fun AboutScreen(navigator: DestinationsNavigator) {
 
             RivoExpressiveCard {
                 RivoListItem(
-                    headline = "Source Code",
-                    supporting = "View the source code on GitHub",
+                    headline = stringResource(R.string.about_source_code),
+                    supporting = stringResource(R.string.about_source_code_supporting),
                     leadingIcon = Icons.Outlined.Code,
                     onClick = { openLink(context, GITHUB_URL) }
                 )
                 HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 RivoListItem(
-                    headline = "Check for Updates",
-                    supporting = "Current version: ${appInfo.first}",
+                    headline = stringResource(R.string.about_check_updates),
+                    supporting = stringResource(R.string.about_current_version, appInfo.first),
                     leadingIcon = Icons.Outlined.SystemUpdate,
                     onClick = { openLink(context, "$GITHUB_URL/releases") }
                 )
@@ -163,7 +164,7 @@ fun AboutScreen(navigator: DestinationsNavigator) {
             Spacer(modifier = Modifier.height(18.dp))
 
             Text(
-                text = "© 2025-2026 RivoPhone Project",
+                text = stringResource(R.string.about_copyright),
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.outline
             )

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/BackupRestoreScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/BackupRestoreScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.BackupViewModel
 import com.grinch.rivo4.view.components.RivoExpressiveCard
 import com.grinch.rivo4.view.components.RivoListItem
@@ -67,10 +69,10 @@ fun BackupRestoreScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Backup & Restore", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_backup_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -87,7 +89,7 @@ fun BackupRestoreScreen(
         ) {
             item {
                 Text(
-                    "Contacts",
+                    stringResource(R.string.settings_backup_contacts_header),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(start = 8.dp)
@@ -95,15 +97,15 @@ fun BackupRestoreScreen(
                 Spacer(Modifier.height(8.dp))
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Export Contacts",
-                        supporting = "Save contacts to a VCF file",
+                        headline = stringResource(R.string.settings_backup_export_contacts),
+                        supporting = stringResource(R.string.settings_backup_export_contacts_supporting),
                         leadingIcon = Icons.Outlined.FileUpload,
                         onClick = { exportContactsLauncher.launch("contacts_backup.vcf") }
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoListItem(
-                        headline = "Import Contacts",
-                        supporting = "Restore contacts from a VCF file",
+                        headline = stringResource(R.string.settings_backup_import_contacts),
+                        supporting = stringResource(R.string.settings_backup_import_contacts_supporting),
                         leadingIcon = Icons.Outlined.FileDownload,
                         onClick = { importContactsLauncher.launch(arrayOf("text/vcard", "text/x-vcard")) }
                     )
@@ -112,7 +114,7 @@ fun BackupRestoreScreen(
 
             item {
                 Text(
-                    "Call Logs",
+                    stringResource(R.string.settings_backup_call_logs_header),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     modifier = Modifier.padding(start = 8.dp)
@@ -120,15 +122,15 @@ fun BackupRestoreScreen(
                 Spacer(Modifier.height(8.dp))
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Export Call Logs",
-                        supporting = "Save history to a JSON file",
+                        headline = stringResource(R.string.settings_backup_export_logs),
+                        supporting = stringResource(R.string.settings_backup_export_logs_supporting),
                         leadingIcon = Icons.Outlined.History,
                         onClick = { exportLogsLauncher.launch("call_logs_backup.json") }
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoListItem(
-                        headline = "Import Call Logs",
-                        supporting = "Restore history from a JSON file",
+                        headline = stringResource(R.string.settings_backup_import_logs),
+                        supporting = stringResource(R.string.settings_backup_import_logs_supporting),
                         leadingIcon = Icons.Outlined.Restore,
                         onClick = { importLogsLauncher.launch(arrayOf("application/json")) }
                     )

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/BlockedNumbersScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/BlockedNumbersScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.view.components.RivoExpressiveCard
 import com.grinch.rivo4.view.components.RivoSelectListItem
@@ -40,10 +42,10 @@ fun BlockedNumbersScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Blocked Numbers", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_blocked_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -59,12 +61,12 @@ fun BlockedNumbersScreen(
             item {
                 RivoExpressiveCard {
                     RivoSelectListItem(
-                        headline = "Block method",
-                        supporting = "How blocked calls are handled",
+                        headline = stringResource(R.string.settings_blocked_method),
+                        supporting = stringResource(R.string.settings_blocked_method_supporting),
                         leadingIcon = Icons.Outlined.Gavel,
                         options = listOf(
-                            "Decline automatically" to 0,
-                            "Ring silently" to 1
+                            stringResource(R.string.settings_blocked_method_decline) to 0,
+                            stringResource(R.string.settings_blocked_method_silent) to 1
                         ),
                         selectedValue = blockMethod,
                         onValueChange = {
@@ -74,12 +76,12 @@ fun BlockedNumbersScreen(
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoSelectListItem(
-                        headline = "Log visibility",
-                        supporting = "Show or hide blocked calls in recents",
+                        headline = stringResource(R.string.settings_blocked_log_visibility),
+                        supporting = stringResource(R.string.settings_blocked_log_visibility_supporting),
                         leadingIcon = Icons.Outlined.Visibility,
                         options = listOf(
-                            "Hide from logs" to 0,
-                            "Show in logs" to 1
+                            stringResource(R.string.settings_blocked_log_hide) to 0,
+                            stringResource(R.string.settings_blocked_log_show) to 1
                         ),
                         selectedValue = logVisibility,
                         onValueChange = {
@@ -93,8 +95,8 @@ fun BlockedNumbersScreen(
             item {
                 RivoExpressiveCard {
                     RivoSwitchListItem(
-                        headline = "Block notifications",
-                        supporting = "Show a low-priority alert for blocked calls",
+                        headline = stringResource(R.string.settings_blocked_notifications),
+                        supporting = stringResource(R.string.settings_blocked_notifications_supporting),
                         leadingIcon = Icons.Outlined.NotificationsPaused,
                         checked = blockNotification,
                         onCheckedChange = {
@@ -104,10 +106,10 @@ fun BlockedNumbersScreen(
                     )
                 }
             }
-            
+
             item {
                 Button(
-                    onClick = { 
+                    onClick = {
                         val telecomManager = context.getSystemService(Context.TELECOM_SERVICE) as TelecomManager
                         try {
                             val intent = telecomManager.createManageBlockedNumbersIntent()
@@ -121,7 +123,7 @@ fun BlockedNumbersScreen(
                 ) {
                     Icon(Icons.AutoMirrored.Outlined.List, null)
                     Spacer(Modifier.width(8.dp))
-                    Text("System Blocked Numbers")
+                    Text(stringResource(R.string.settings_blocked_system_button))
                 }
             }
         }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/CallAccountsScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/CallAccountsScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.view.components.RivoDialog
 import com.grinch.rivo4.view.components.RivoExpressiveCard
@@ -66,10 +68,10 @@ fun CallAccountsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Call Settings", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_call_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -94,29 +96,30 @@ fun CallAccountsScreen(
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             item {
+                val askEveryTimeLabel = stringResource(R.string.sim_ask_every_time)
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Speed dial",
-                        supporting = if (speedDial) "Enabled" else "Disabled",
+                        headline = stringResource(R.string.settings_call_speed_dial),
+                        supporting = if (speedDial) stringResource(R.string.settings_call_enabled) else stringResource(R.string.settings_call_disabled),
                         leadingIcon = Icons.Outlined.Speed,
                         onClick = { navigator.navigate(SpeedDialScreenDestination) }
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoListItem(
-                        headline = "Default SIM",
+                        headline = stringResource(R.string.settings_call_default_sim),
                         supporting = when(defaultSim) {
-                            0 -> "Ask every time"
-                            1 -> "SIM 1"
-                            2 -> "SIM 2"
-                            else -> "Ask every time"
+                            0 -> askEveryTimeLabel
+                            1 -> stringResource(R.string.sim_slot_1)
+                            2 -> stringResource(R.string.sim_slot_2)
+                            else -> askEveryTimeLabel
                         },
                         leadingIcon = Icons.Outlined.SimCard,
                         onClick = { showSimDialog = true }
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoListItem(
-                        headline = "Calling accounts",
-                        supporting = "Configure carrier settings (Call Waiting, Forwarding, etc.)",
+                        headline = stringResource(R.string.settings_call_calling_accounts),
+                        supporting = stringResource(R.string.settings_call_calling_accounts_supporting),
                         leadingIcon = Icons.Outlined.Settings,
                         onClick = {
                             try {
@@ -147,8 +150,8 @@ fun CallAccountsScreen(
             item {
                 RivoExpressiveCard {
                     RivoSwitchListItem(
-                        headline = "T9 Dialing",
-                        supporting = "Predicts words from numeric keypad inputs",
+                        headline = stringResource(R.string.settings_call_t9_dialing),
+                        supporting = stringResource(R.string.settings_call_t9_dialing_supporting),
                         leadingIcon = Icons.Outlined.Dialpad,
                         checked = t9Dialing,
                         onCheckedChange = {
@@ -158,8 +161,8 @@ fun CallAccountsScreen(
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoSwitchListItem(
-                        headline = "Proximity Sensor",
-                        supporting = "Turn off screen during calls when near ear",
+                        headline = stringResource(R.string.settings_call_proximity_sensor),
+                        supporting = stringResource(R.string.settings_call_proximity_sensor_supporting),
                         leadingIcon = Icons.Outlined.Sensors,
                         checked = proximitySensor,
                         onCheckedChange = {
@@ -169,14 +172,14 @@ fun CallAccountsScreen(
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoSelectListItem(
-                        headline = "Incoming Call UI",
-                        supporting = "Choose how to answer incoming calls",
+                        headline = stringResource(R.string.settings_call_incoming_ui),
+                        supporting = stringResource(R.string.settings_call_incoming_ui_supporting),
                         leadingIcon = Icons.Outlined.PhoneInTalk,
                         options = listOf(
-                            "Horizontal Swipe" to 0,
-                            "Buttons" to 1,
-                            "Slide to Answer (iOS)" to 2,
-                            "Vertical Swipe" to 3
+                            stringResource(R.string.settings_call_incoming_ui_horizontal_swipe) to 0,
+                            stringResource(R.string.settings_call_incoming_ui_buttons) to 1,
+                            stringResource(R.string.settings_call_incoming_ui_slide_ios) to 2,
+                            stringResource(R.string.settings_call_incoming_ui_vertical_swipe) to 3
                         ),
                         selectedValue = incomingCallUI,
                         onValueChange = {
@@ -186,13 +189,13 @@ fun CallAccountsScreen(
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoSelectListItem(
-                        headline = "Dialpad Style",
-                        supporting = "Visual appearance of the phone dialer",
+                        headline = stringResource(R.string.settings_call_dialpad_style),
+                        supporting = stringResource(R.string.settings_call_dialpad_style_supporting),
                         leadingIcon = Icons.Outlined.Dialpad,
                         options = listOf(
-                            "Modern" to 0,
-                            "Classic" to 1,
-                            "Minimal" to 2
+                            stringResource(R.string.settings_call_dialpad_style_modern) to 0,
+                            stringResource(R.string.settings_call_dialpad_style_classic) to 1,
+                            stringResource(R.string.settings_call_dialpad_style_minimal) to 2
                         ),
                         selectedValue = dialpadStyle,
                         onValueChange = {
@@ -202,13 +205,13 @@ fun CallAccountsScreen(
                     )
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoSelectListItem(
-                        headline = "Dialpad Layout",
-                        supporting = "Alignment for one-handed use",
+                        headline = stringResource(R.string.settings_call_dialpad_layout),
+                        supporting = stringResource(R.string.settings_call_dialpad_layout_supporting),
                         leadingIcon = Icons.Outlined.AlignHorizontalLeft,
                         options = listOf(
-                            "Standard" to 0,
-                            "Left" to 1,
-                            "Right" to 2
+                            stringResource(R.string.option_standard) to 0,
+                            stringResource(R.string.settings_call_dialpad_layout_left) to 1,
+                            stringResource(R.string.settings_call_dialpad_layout_right) to 2
                         ),
                         selectedValue = dialpadLayout,
                         onValueChange = {
@@ -222,8 +225,8 @@ fun CallAccountsScreen(
             item {
                 RivoExpressiveCard {
                     RivoSwitchListItem(
-                        headline = "Auto Redial",
-                        supporting = "Automatically redial if the line is busy",
+                        headline = stringResource(R.string.settings_call_auto_redial),
+                        supporting = stringResource(R.string.settings_call_auto_redial_supporting),
                         leadingIcon = Icons.Outlined.Replay,
                         checked = autoRedial,
                         onCheckedChange = {
@@ -234,15 +237,15 @@ fun CallAccountsScreen(
                     if (autoRedial) {
                         HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                         RivoSelectListItem(
-                            headline = "Redial Attempts",
-                            supporting = "Maximum number of redial attempts",
+                            headline = stringResource(R.string.settings_call_redial_attempts),
+                            supporting = stringResource(R.string.settings_call_redial_attempts_supporting),
                             leadingIcon = Icons.Outlined.Refresh,
                             options = listOf(
-                                "1 attempt" to 1,
-                                "2 attempts" to 2,
-                                "3 attempts" to 3,
-                                "5 attempts" to 5,
-                                "10 attempts" to 10
+                                stringResource(R.string.settings_call_redial_attempts_1) to 1,
+                                stringResource(R.string.settings_call_redial_attempts_2) to 2,
+                                stringResource(R.string.settings_call_redial_attempts_3) to 3,
+                                stringResource(R.string.settings_call_redial_attempts_5) to 5,
+                                stringResource(R.string.settings_call_redial_attempts_10) to 10
                             ),
                             selectedValue = redialAttempts,
                             onValueChange = {
@@ -252,15 +255,15 @@ fun CallAccountsScreen(
                         )
                         HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                         RivoSelectListItem(
-                            headline = "Redial Delay",
-                            supporting = "Delay between redial attempts",
+                            headline = stringResource(R.string.settings_call_redial_delay),
+                            supporting = stringResource(R.string.settings_call_redial_delay_supporting),
                             leadingIcon = Icons.Outlined.Timer,
                             options = listOf(
-                                "1 second" to 1000,
-                                "2 seconds" to 2000,
-                                "3 seconds" to 3000,
-                                "5 seconds" to 5000,
-                                "10 seconds" to 10000
+                                stringResource(R.string.settings_call_redial_delay_1s) to 1000,
+                                stringResource(R.string.settings_call_redial_delay_2s) to 2000,
+                                stringResource(R.string.settings_call_redial_delay_3s) to 3000,
+                                stringResource(R.string.settings_call_redial_delay_5s) to 5000,
+                                stringResource(R.string.settings_call_redial_delay_10s) to 10000
                             ),
                             selectedValue = redialDelay,
                             onValueChange = {
@@ -271,8 +274,8 @@ fun CallAccountsScreen(
                     }
                     HorizontalDivider(Modifier.padding(horizontal = 16.dp), color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                     RivoListItem(
-                        headline = "Voicemail",
-                        supporting = "Configure your mailbox",
+                        headline = stringResource(R.string.settings_call_voicemail),
+                        supporting = stringResource(R.string.settings_call_voicemail_supporting),
                         leadingIcon = Icons.Outlined.Voicemail,
                         onClick = { navigator.navigate(VoicemailScreenDestination) }
                     )
@@ -288,15 +291,15 @@ fun CallAccountsScreen(
     if (showSimDialog) {
         RivoDialog(
             onDismissRequest = { showSimDialog = false },
-            title = "Default SIM",
+            title = stringResource(R.string.settings_call_default_sim),
             icon = Icons.Outlined.SimCard,
             dismissButton = {
                 TextButton(onClick = { showSimDialog = false }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.action_cancel))
                 }
             }
         ) {
-            listOf("Ask every time", "SIM 1", "SIM 2").forEachIndexed { index, label ->
+            listOf(stringResource(R.string.sim_ask_every_time), stringResource(R.string.sim_slot_1), stringResource(R.string.sim_slot_2)).forEachIndexed { index, label ->
                 Surface(
                     onClick = {
                         defaultSim = index

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/ContactManagementScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/ContactManagementScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.modal.data.Contact
@@ -42,7 +44,7 @@ fun ContactManagementScreen(
     if (standardizeProgress != null) {
         RivoDialog(
             onDismissRequest = {},
-            title = "Standardizing numbers",
+            title = stringResource(R.string.settings_manage_standardizing_title),
             icon = Icons.Outlined.FormatListNumbered
         ) {
             Spacer(modifier = Modifier.height(8.dp))
@@ -53,7 +55,7 @@ fun ContactManagementScreen(
             )
             Spacer(modifier = Modifier.height(12.dp))
             Text(
-                text = "${(progress * 100).toInt()}% completed",
+                text = stringResource(R.string.settings_manage_percent_completed, (progress * 100).toInt()),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.align(Alignment.End)
@@ -71,10 +73,10 @@ fun ContactManagementScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Manage Contacts", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_manage_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -93,30 +95,30 @@ fun ContactManagementScreen(
                 item {
                     val sortOrder by viewModel.sortOrder.collectAsState()
                     val displayOrder by viewModel.displayOrder.collectAsState()
-                    
+
                     RivoExpressiveCard(
-                        title = "Display & Sorting",
+                        title = stringResource(R.string.settings_manage_display_sorting),
                         icon = Icons.Outlined.DisplaySettings
                     ) {
                         RivoSelectListItem(
-                            headline = "Sort by",
-                            supporting = "Choose how contacts are ordered",
+                            headline = stringResource(R.string.settings_manage_sort_by),
+                            supporting = stringResource(R.string.settings_manage_sort_by_supporting),
                             leadingIcon = Icons.Outlined.SortByAlpha,
                             options = listOf(
-                                "First Name" to 0,
-                                "Last Name" to 1
+                                stringResource(R.string.settings_manage_sort_first_name) to 0,
+                                stringResource(R.string.settings_manage_sort_last_name) to 1
                             ),
                             selectedValue = sortOrder,
                             onValueChange = { newValue: Int -> viewModel.setSortOrder(newValue) }
                         )
                         RivoDivider(modifier = Modifier.padding(horizontal = 16.dp))
                         RivoSelectListItem(
-                            headline = "Name format",
-                            supporting = "Choose how names are displayed",
+                            headline = stringResource(R.string.settings_manage_name_format),
+                            supporting = stringResource(R.string.settings_manage_name_format_supporting),
                             leadingIcon = Icons.Outlined.Badge,
                             options = listOf(
-                                "First Name First" to 0,
-                                "Last Name First" to 1
+                                stringResource(R.string.settings_manage_name_format_first_first) to 0,
+                                stringResource(R.string.settings_manage_name_format_last_first) to 1
                             ),
                             selectedValue = displayOrder,
                             onValueChange = { newValue: Int -> viewModel.setDisplayOrder(newValue) }
@@ -126,19 +128,19 @@ fun ContactManagementScreen(
 
                 item {
                     RivoExpressiveCard(
-                        title = "Storage",
+                        title = stringResource(R.string.settings_manage_storage),
                         icon = Icons.Outlined.Storage
                     ) {
                         RivoListItem(
-                            headline = "Private Contacts",
-                            supporting = "Manage contacts stored only in this app",
+                            headline = stringResource(R.string.settings_manage_private_contacts),
+                            supporting = stringResource(R.string.settings_manage_private_contacts_supporting),
                             leadingIcon = Icons.Outlined.Lock,
                             onClick = { navigator.navigate(PrivateContactsScreenDestination) }
                         )
                         RivoDivider(modifier = Modifier.padding(horizontal = 16.dp))
                         RivoListItem(
-                            headline = "Visibility",
-                            supporting = "Choose which accounts to show in your list",
+                            headline = stringResource(R.string.settings_manage_visibility),
+                            supporting = stringResource(R.string.settings_manage_visibility_supporting),
                             leadingIcon = Icons.Outlined.Visibility,
                             onClick = { navigator.navigate(ContactVisibilityScreenDestination) }
                         )
@@ -147,12 +149,12 @@ fun ContactManagementScreen(
 
                 item {
                     RivoExpressiveCard(
-                        title = "Quick Fixes",
+                        title = stringResource(R.string.settings_manage_quick_fixes),
                         icon = Icons.Outlined.AutoFixHigh
                     ) {
                         RivoListItem(
-                            headline = "Standardize phone numbers",
-                            supporting = "Remove spaces and special characters from all numbers",
+                            headline = stringResource(R.string.settings_manage_standardize_numbers),
+                            supporting = stringResource(R.string.settings_manage_standardize_numbers_supporting),
                             leadingIcon = Icons.Outlined.FormatListNumbered,
                             onClick = { viewModel.formatAllPhoneNumbers() }
                         )
@@ -162,13 +164,13 @@ fun ContactManagementScreen(
                 if (duplicateGroups.isEmpty()) {
                     item {
                         Box(modifier = Modifier.fillParentMaxSize(), contentAlignment = Alignment.Center) {
-                            Text("No duplicates found.", style = MaterialTheme.typography.bodyLarge)
+                            Text(stringResource(R.string.settings_manage_no_duplicates), style = MaterialTheme.typography.bodyLarge)
                         }
                     }
                 } else {
                     item {
                         Text(
-                            "Found ${duplicateGroups.size} groups of duplicates",
+                            stringResource(R.string.settings_manage_found_duplicates, duplicateGroups.size),
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.Bold,
                             modifier = Modifier.padding(start = 8.dp)
@@ -216,7 +218,7 @@ fun DuplicateGroupCard(
         ) {
             Icon(Icons.Outlined.Merge, null)
             Spacer(Modifier.width(8.dp))
-            Text("Merge duplicates")
+            Text(stringResource(R.string.settings_manage_merge_duplicates))
         }
     }
 }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/ContactVisibilityScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/ContactVisibilityScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.ContactUtils
 import com.grinch.rivo4.view.components.RivoExpressiveCard
@@ -43,10 +45,10 @@ fun ContactVisibilityScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Contact Visibility", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_visibility_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -61,7 +63,7 @@ fun ContactVisibilityScreen(
         ) {
             item {
                 Text(
-                    text = "Select which accounts should be visible in your contact list. Deselecting an account will hide its contacts but won't delete them.",
+                    text = stringResource(R.string.settings_visibility_description),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 8.dp)
@@ -70,12 +72,12 @@ fun ContactVisibilityScreen(
 
             item {
                 RivoExpressiveCard(
-                    title = "Accounts",
+                    title = stringResource(R.string.settings_visibility_accounts_header),
                     icon = Icons.Default.Visibility
                 ) {
                     RivoSwitchListItem(
-                        headline = "Local Memory",
-                        supporting = "Contacts stored on device",
+                        headline = stringResource(R.string.label_local_memory),
+                        supporting = stringResource(R.string.settings_visibility_local_memory_supporting),
                         leadingIcon = Icons.Default.CloudOff,
                         checked = currentVisible.contains("local|local"),
                         onCheckedChange = { isChecked: Boolean -> toggleAccount("local|local", isChecked) }
@@ -93,13 +95,13 @@ fun ContactVisibilityScreen(
                     }
                 }
             }
-            
+
             item {
                 TextButton(
                     onClick = { viewModel.setVisibleAccounts(null) },
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Text("Reset to Show All")
+                    Text(stringResource(R.string.settings_visibility_reset_all))
                 }
             }
         }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/ContributorsScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/ContributorsScreen.kt
@@ -1,5 +1,6 @@
 package com.grinch.rivo4.view.screen.settings
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
@@ -11,8 +12,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.openLink
 import com.grinch.rivo4.view.components.RivoExpressiveCard
 import com.grinch.rivo4.view.components.RivoListItem
@@ -22,14 +25,14 @@ import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 
 data class Contributor(
     val name: String,
-    val role: String,
+    @StringRes val role: Int,
     val githubUrl: String? = null,
     val imageAsset: String? = null
 )
 
 val appContributors = listOf(
-    Contributor("Grinch_", "Lead Developer", "https://github.com/user-grinch", "grinch.jpeg"),
-    Contributor("Hamma", "Developer", "https://github.com/MoHamed-B-M", "hamma.jpeg")
+    Contributor("Grinch_", R.string.contributor_role_lead_developer, "https://github.com/user-grinch", "grinch.jpeg"),
+    Contributor("Hamma", R.string.contributor_role_developer, "https://github.com/MoHamed-B-M", "hamma.jpeg")
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,10 +45,10 @@ fun ContributorsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Contributors", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.contributors_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -63,7 +66,7 @@ fun ContributorsScreen(
                     appContributors.forEachIndexed { index, contributor ->
                         RivoListItem(
                             headline = contributor.name,
-                            supporting = contributor.role,
+                            supporting = stringResource(contributor.role),
                             avatarName = contributor.name,
                             photoUri = contributor.imageAsset?.let { "file:///android_asset/contributors/$it" },
                             trailingIcon = if (contributor.githubUrl != null) Icons.Outlined.Launch else null,

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/InterfaceScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/InterfaceScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.view.components.RivoDivider
 import com.grinch.rivo4.view.components.RivoExpressiveCard
@@ -77,11 +79,14 @@ fun InterfaceScreen(
         Color(0xFF436916), Color(0xFF984061), Color(0xFF808080)
     )
 
+    val restartRequiredMessage = stringResource(R.string.settings_interface_restart_required)
+    val restartActionLabel = stringResource(R.string.settings_interface_restart_action)
+
     fun showRestartPrompt() {
         scope.launch {
             val result = snackbarHostState.showSnackbar(
-                message = "Restart required to apply theme changes fully.",
-                actionLabel = "Restart",
+                message = restartRequiredMessage,
+                actionLabel = restartActionLabel,
                 duration = SnackbarDuration.Short
             )
             if (result == SnackbarResult.ActionPerformed) {
@@ -93,10 +98,10 @@ fun InterfaceScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("User Interface", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_interface_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -114,8 +119,8 @@ fun InterfaceScreen(
                 item {
                     RivoExpressiveCard {
                         RivoSwitchListItem(
-                            headline = "Material You theming",
-                            supporting = "Wallpaper based app color theming.",
+                            headline = stringResource(R.string.settings_interface_material_you),
+                            supporting = stringResource(R.string.settings_interface_material_you_supporting),
                             leadingIcon = Icons.Outlined.Palette,
                             checked = dynamicColors,
                             onCheckedChange = {
@@ -124,11 +129,11 @@ fun InterfaceScreen(
                                 showRestartPrompt()
                             }
                         )
-                        
+
                         if (!dynamicColors) {
                             RivoDivider(Modifier.padding(horizontal = 16.dp))
                             Column(modifier = Modifier.padding(16.dp)) {
-                                Text("Primary Color", style = MaterialTheme.typography.labelLarge)
+                                Text(stringResource(R.string.settings_interface_primary_color), style = MaterialTheme.typography.labelLarge)
                                 Spacer(Modifier.height(12.dp))
                                 LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                                     items(presetColors) { color ->
@@ -155,8 +160,8 @@ fun InterfaceScreen(
                         
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSwitchListItem(
-                            headline = "Amoled dark mode",
-                            supporting = "Uses pitch black for UI elements.",
+                            headline = stringResource(R.string.settings_interface_amoled),
+                            supporting = stringResource(R.string.settings_interface_amoled_supporting),
                             leadingIcon = Icons.Outlined.DarkMode,
                             checked = amoledMode,
                             onCheckedChange = {
@@ -171,8 +176,8 @@ fun InterfaceScreen(
                 item {
                     RivoExpressiveCard {
                         RivoSwitchListItem(
-                            headline = "Show first letter in avatar",
-                            supporting = "Displays letter when picture is missing",
+                            headline = stringResource(R.string.settings_interface_show_first_letter),
+                            supporting = stringResource(R.string.settings_interface_show_first_letter_supporting),
                             leadingIcon = Icons.Outlined.Title,
                             checked = showFirstLetter,
                             onCheckedChange = {
@@ -182,8 +187,8 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSwitchListItem(
-                            headline = "Use colorful avatars",
-                            supporting = "Random colors based on contact name",
+                            headline = stringResource(R.string.settings_interface_colorful_avatars),
+                            supporting = stringResource(R.string.settings_interface_colorful_avatars_supporting),
                             leadingIcon = Icons.Outlined.Palette,
                             checked = colorfulAvatars,
                             onCheckedChange = {
@@ -193,8 +198,8 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSwitchListItem(
-                            headline = "Show picture in avatar",
-                            supporting = "Shows the contact picture if available",
+                            headline = stringResource(R.string.settings_interface_show_picture),
+                            supporting = stringResource(R.string.settings_interface_show_picture_supporting),
                             leadingIcon = Icons.Outlined.AccountCircle,
                             checked = showPicture,
                             onCheckedChange = {
@@ -204,13 +209,13 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSelectListItem(
-                            headline = "Avatar shape",
-                            supporting = "Choose the shape for contact avatars",
+                            headline = stringResource(R.string.settings_interface_avatar_shape),
+                            supporting = stringResource(R.string.settings_interface_avatar_shape_supporting),
                             leadingIcon = Icons.Outlined.AccountBox,
                             options = listOf(
-                                "Squircle" to 0,
-                                "Circle" to 1,
-                                "Square" to 2
+                                stringResource(R.string.settings_interface_avatar_shape_squircle) to 0,
+                                stringResource(R.string.settings_interface_avatar_shape_circle) to 1,
+                                stringResource(R.string.settings_interface_avatar_shape_square) to 2
                             ),
                             selectedValue = avatarShape,
                             onValueChange = {
@@ -220,8 +225,8 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSwitchListItem(
-                            headline = "Call screen avatar",
-                            supporting = "Show contact picture on call screen",
+                            headline = stringResource(R.string.settings_interface_call_screen_avatar),
+                            supporting = stringResource(R.string.settings_interface_call_screen_avatar_supporting),
                             leadingIcon = Icons.Outlined.ContactPage,
                             checked = showCallScreenAvatar,
                             onCheckedChange = {
@@ -235,8 +240,8 @@ fun InterfaceScreen(
                 item {
                     RivoExpressiveCard {
                         RivoSwitchListItem(
-                            headline = "Show dividers",
-                            supporting = "Display lines between list items",
+                            headline = stringResource(R.string.settings_interface_show_dividers),
+                            supporting = stringResource(R.string.settings_interface_show_dividers_supporting),
                             leadingIcon = Icons.Outlined.HorizontalRule,
                             checked = showDividers,
                             onCheckedChange = {
@@ -246,8 +251,8 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSwitchListItem(
-                            headline = "Use expressive cards",
-                            supporting = "Wraps list items in styled cards",
+                            headline = stringResource(R.string.settings_interface_expressive_cards),
+                            supporting = stringResource(R.string.settings_interface_expressive_cards_supporting),
                             leadingIcon = Icons.Outlined.DashboardCustomize,
                             checked = showCards,
                             onCheckedChange = {
@@ -257,14 +262,14 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSelectListItem(
-                            headline = "Transition animation",
-                            supporting = "Style of animations between screens",
+                            headline = stringResource(R.string.settings_interface_transition_animation),
+                            supporting = stringResource(R.string.settings_interface_transition_animation_supporting),
                             leadingIcon = Icons.Outlined.Animation,
                             options = listOf(
-                                "Standard" to 0,
-                                "Slide" to 1,
-                                "Fade" to 2,
-                                "None" to 3
+                                stringResource(R.string.option_standard) to 0,
+                                stringResource(R.string.settings_interface_transition_slide) to 1,
+                                stringResource(R.string.settings_interface_transition_fade) to 2,
+                                stringResource(R.string.settings_interface_transition_none) to 3
                             ),
                             selectedValue = transitionStyle,
                             onValueChange = {
@@ -274,13 +279,13 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSelectListItem(
-                            headline = "Search Matching Mode",
-                            supporting = "Behavior of contacts filtering algorithm",
+                            headline = stringResource(R.string.settings_interface_search_matching_mode),
+                            supporting = stringResource(R.string.settings_interface_search_matching_mode_supporting),
                             leadingIcon = Icons.Outlined.Search,
                             options = listOf(
-                                "T9 & Contains" to 0,
-                                "Starts With" to 1,
-                                "Exact Match" to 2
+                                stringResource(R.string.settings_interface_search_mode_t9_contains) to 0,
+                                stringResource(R.string.settings_interface_search_mode_starts_with) to 1,
+                                stringResource(R.string.settings_interface_search_mode_exact_match) to 2
                             ),
                             selectedValue = searchMatchMode,
                             onValueChange = {
@@ -290,15 +295,15 @@ fun InterfaceScreen(
                         )
                         RivoDivider(Modifier.padding(horizontal = 16.dp))
                         RivoSelectListItem(
-                            headline = "Card roundness",
-                            supporting = "Adjust the corner radius of UI cards",
+                            headline = stringResource(R.string.settings_interface_card_roundness),
+                            supporting = stringResource(R.string.settings_interface_card_roundness_supporting),
                             leadingIcon = Icons.Outlined.CropFree,
                             options = listOf(
-                                "Extra Round" to 32,
-                                "Standard" to 28,
-                                "Rounded" to 20,
-                                "Semi Square" to 12,
-                                "Square" to 0
+                                stringResource(R.string.settings_interface_roundness_extra_round) to 32,
+                                stringResource(R.string.option_standard) to 28,
+                                stringResource(R.string.settings_interface_roundness_rounded) to 20,
+                                stringResource(R.string.settings_interface_roundness_semi_square) to 12,
+                                stringResource(R.string.settings_interface_roundness_square) to 0
                             ),
                             selectedValue = cardRoundness,
                             onValueChange = {
@@ -312,12 +317,12 @@ fun InterfaceScreen(
                 item {
                     RivoExpressiveCard {
                         RivoSelectListItem(
-                            headline = "Default bottom bar",
-                            supporting = "Select which tab opens initially",
+                            headline = stringResource(R.string.settings_interface_default_bottom_bar),
+                            supporting = stringResource(R.string.settings_interface_default_bottom_bar_supporting),
                             leadingIcon = Icons.Outlined.SpaceDashboard,
                             options = listOf(
-                                "Contacts" to 0,
-                                "Recents" to 1,
+                                stringResource(R.string.nav_contacts) to 0,
+                                stringResource(R.string.nav_recents) to 1,
                             ),
                             selectedValue = defaultBottomBar,
                             onValueChange = { selectedInt ->
@@ -326,8 +331,8 @@ fun InterfaceScreen(
                             }
                         )
                         RivoSwitchListItem(
-                            headline = "Flip bottom bar",
-                            supporting = "Flips the position of the contacts & recents tabs",
+                            headline = stringResource(R.string.settings_interface_flip_bottom_bar),
+                            supporting = stringResource(R.string.settings_interface_flip_bottom_bar_supporting),
                             leadingIcon = Icons.Outlined.SwapHoriz,
                             checked = flipBottomBar,
                             onCheckedChange = {
@@ -336,8 +341,8 @@ fun InterfaceScreen(
                             }
                         )
                         RivoSwitchListItem(
-                            headline = "Icon-only bottom bar",
-                            supporting = "Removes text labels from navigation",
+                            headline = stringResource(R.string.settings_interface_icon_only_bar),
+                            supporting = stringResource(R.string.settings_interface_icon_only_bar_supporting),
                             leadingIcon = Icons.Outlined.ViewStream,
                             checked = iconOnlyNav,
                             onCheckedChange = {

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/PrivateContactsScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/PrivateContactsScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.modal.data.Contact
 import com.grinch.rivo4.view.components.RivoAvatar
@@ -60,18 +62,18 @@ fun PrivateContactsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Private Contacts", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_private_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 },
                 actions = {
                     IconButton(onClick = { importLauncher.launch("text/vcard") }) {
-                        Icon(Icons.Default.FileDownload, "Import")
+                        Icon(Icons.Default.FileDownload, stringResource(R.string.content_desc_import))
                     }
                     IconButton(onClick = { exportLauncher.launch("private_contacts.vcf") }) {
-                        Icon(Icons.Default.FileUpload, "Export")
+                        Icon(Icons.Default.FileUpload, stringResource(R.string.content_desc_export))
                     }
                 }
             )
@@ -84,7 +86,7 @@ fun PrivateContactsScreen(
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Icon(Icons.Default.Lock, null, modifier = Modifier.size(64.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f))
                     Spacer(Modifier.height(16.dp))
-                    Text("No private contacts found", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(stringResource(R.string.settings_private_empty), style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         } else {
@@ -95,7 +97,7 @@ fun PrivateContactsScreen(
             ) {
                 item {
                     Text(
-                        "Manage your encrypted local contacts",
+                        stringResource(R.string.settings_private_manage_hint),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.padding(start = 8.dp, bottom = 4.dp)
@@ -141,7 +143,7 @@ fun PrivateContactCard(
                 }
                 DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
                     DropdownMenuItem(
-                        text = { Text("Move to Public Storage") },
+                        text = { Text(stringResource(R.string.contact_move_to_public_storage)) },
                         onClick = {
                             showMenu = false
                             onMoveToPublic()
@@ -149,7 +151,7 @@ fun PrivateContactCard(
                         leadingIcon = { Icon(Icons.Default.LockOpen, null) }
                     )
                     DropdownMenuItem(
-                        text = { Text("Delete") },
+                        text = { Text(stringResource(R.string.action_delete)) },
                         onClick = {
                             showMenu = false
                             onDelete()

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/SettingsScreen.kt
@@ -27,9 +27,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.PATREON_URL
 import com.grinch.rivo4.controller.util.openLink
 import com.grinch.rivo4.view.components.RivoDivider
@@ -55,10 +57,10 @@ fun SettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Settings", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -99,13 +101,13 @@ fun SettingsScreen(
                         Spacer(modifier = Modifier.width(16.dp))
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                "Support Rivo",
+                                stringResource(R.string.settings_support_rivo_title),
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.Bold,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer
                             )
                             Text(
-                                "Help us keep Rivo free and open source",
+                                stringResource(R.string.settings_support_rivo_description),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
                             )
@@ -119,44 +121,44 @@ fun SettingsScreen(
                             shape = MaterialTheme.shapes.medium,
                             contentPadding = PaddingValues(horizontal = 16.dp)
                         ) {
-                            Text("Donate")
+                            Text(stringResource(R.string.settings_donate))
                         }
                     }
                 }
             }
 
-            
+
             item {
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Interface",
-                        supporting = "Theme, colors, and accessibility",
+                        headline = stringResource(R.string.settings_interface_headline),
+                        supporting = stringResource(R.string.settings_interface_supporting),
                         leadingIcon = Icons.Outlined.Palette,
                         onClick = { navigator.navigate(InterfaceScreenDestination) }
                     )
                     RivoDivider(Modifier.padding(horizontal = 16.dp))
                     RivoListItem(
-                        headline = "Sound & Vibration",
-                        supporting = "Ringtones and dialpad tones",
+                        headline = stringResource(R.string.settings_sound_vibration_headline),
+                        supporting = stringResource(R.string.settings_sound_vibration_supporting),
                         leadingIcon = Icons.Outlined.VolumeUp,
                         onClick = { navigator.navigate(SoundVibrationScreenDestination) }
                     )
                 }
             }
 
-            
+
             item {
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Call Settings",
-                        supporting = "Manage SIMs, dialing, and redial",
+                        headline = stringResource(R.string.settings_call_settings_headline),
+                        supporting = stringResource(R.string.settings_call_settings_supporting),
                         leadingIcon = Icons.Outlined.SimCard,
                         onClick = { navigator.navigate(CallAccountsScreenDestination) }
                     )
                     RivoDivider(Modifier.padding(horizontal = 16.dp))
                     RivoListItem(
-                        headline = "Blocked Numbers",
-                        supporting = "Manage blocked calls and spam",
+                        headline = stringResource(R.string.settings_blocked_numbers_headline),
+                        supporting = stringResource(R.string.settings_blocked_numbers_supporting),
                         leadingIcon = Icons.Outlined.Block,
                         onClick = { navigator.navigate(BlockedNumbersScreenDestination) }
                     )
@@ -166,27 +168,27 @@ fun SettingsScreen(
             item {
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Backup & Restore",
-                        supporting = "Import and export contacts and logs",
+                        headline = stringResource(R.string.settings_backup_restore_headline),
+                        supporting = stringResource(R.string.settings_backup_restore_supporting),
                         leadingIcon = Icons.Outlined.Backup,
                         onClick = { navigator.navigate(BackupRestoreScreenDestination) }
                     )
                     RivoDivider(Modifier.padding(horizontal = 16.dp))
                     RivoListItem(
-                        headline = "Manage Contacts",
-                        supporting = "Merge duplicates and clean up your list",
+                        headline = stringResource(R.string.settings_manage_contacts_headline),
+                        supporting = stringResource(R.string.settings_manage_contacts_supporting),
                         leadingIcon = Icons.Outlined.ContactPage,
                         onClick = { navigator.navigate(ContactManagementScreenDestination) }
                     )
                 }
             }
 
-            
+
             item {
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "About Rivo",
-                        supporting = "Version, licenses, and privacy policy",
+                        headline = stringResource(R.string.settings_about_headline),
+                        supporting = stringResource(R.string.settings_about_supporting),
                         leadingIcon = Icons.Outlined.Info,
                         onClick = { navigator.navigate(AboutScreenDestination) }
                     )

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/SoundVibrationScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/SoundVibrationScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.view.components.RivoDivider
 import com.grinch.rivo4.view.components.RivoExpressiveCard
@@ -45,10 +47,10 @@ fun SoundVibrationScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Sound & Vibration", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_sound_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -64,8 +66,8 @@ fun SoundVibrationScreen(
             item {
                 RivoExpressiveCard {
                     RivoSwitchListItem(
-                        headline = "DTMF tone",
-                        supporting = "Dialpad tone that plays during keypress",
+                        headline = stringResource(R.string.settings_sound_dtmf_tone),
+                        supporting = stringResource(R.string.settings_sound_dtmf_tone_supporting),
                         leadingIcon = Icons.Outlined.Audiotrack,
                         checked = dtmfTone,
                         onCheckedChange = {
@@ -75,8 +77,8 @@ fun SoundVibrationScreen(
                     )
                     RivoDivider(Modifier.padding(horizontal = 16.dp))
                     RivoSwitchListItem(
-                        headline = "Dialpad vibration",
-                        supporting = "Dialpad vibration that plays during keypress",
+                        headline = stringResource(R.string.settings_sound_dialpad_vibration),
+                        supporting = stringResource(R.string.settings_sound_dialpad_vibration_supporting),
                         leadingIcon = Icons.Outlined.Vibration,
                         checked = dialpadVibration,
                         onCheckedChange = {
@@ -90,8 +92,8 @@ fun SoundVibrationScreen(
             item {
                 RivoExpressiveCard {
                     RivoSwitchListItem(
-                        headline = "Vibrate on Answer",
-                        supporting = "Vibrate when the other party answers",
+                        headline = stringResource(R.string.settings_sound_vibrate_on_answer),
+                        supporting = stringResource(R.string.settings_sound_vibrate_on_answer_supporting),
                         leadingIcon = Icons.Outlined.Vibration,
                         checked = vibrateOnAnswer,
                         onCheckedChange = {
@@ -101,8 +103,8 @@ fun SoundVibrationScreen(
                     )
                     RivoDivider(Modifier.padding(horizontal = 16.dp))
                     RivoSwitchListItem(
-                        headline = "Vibrate on Hang up",
-                        supporting = "Vibrate when the call ends",
+                        headline = stringResource(R.string.settings_sound_vibrate_on_hangup),
+                        supporting = stringResource(R.string.settings_sound_vibrate_on_hangup_supporting),
                         leadingIcon = Icons.Outlined.Vibration,
                         checked = vibrateOnHangup,
                         onCheckedChange = {
@@ -112,8 +114,8 @@ fun SoundVibrationScreen(
                     )
                     RivoDivider(Modifier.padding(horizontal = 16.dp))
                     RivoSwitchListItem(
-                        headline = "Haptic Scrolling feedback",
-                        supporting = "Vibrate subtly when scrolling lists",
+                        headline = stringResource(R.string.settings_sound_haptic_scroll),
+                        supporting = stringResource(R.string.settings_sound_haptic_scroll_supporting),
                         leadingIcon = Icons.Outlined.Gesture,
                         checked = hapticListScroll,
                         onCheckedChange = {
@@ -127,8 +129,8 @@ fun SoundVibrationScreen(
             item {
                 RivoExpressiveCard {
                     RivoListItem(
-                        headline = "Ringtone Settings",
-                        supporting = "Open system sound settings",
+                        headline = stringResource(R.string.settings_sound_ringtone_settings),
+                        supporting = stringResource(R.string.settings_sound_ringtone_settings_supporting),
                         leadingIcon = Icons.Outlined.MusicNote,
                         onClick = {
                             context.startActivity(Intent(Settings.ACTION_SOUND_SETTINGS))

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/SpeedDialScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/SpeedDialScreen.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.ContactsViewModel
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.modal.data.Contact
@@ -49,10 +51,10 @@ fun SpeedDialScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Speed Dial", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_speed_dial_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -69,8 +71,8 @@ fun SpeedDialScreen(
             item {
                 RivoExpressiveCard {
                     RivoSwitchListItem(
-                        headline = "Enable Speed Dial",
-                        supporting = "Long press a key to call assigned contact",
+                        headline = stringResource(R.string.settings_speed_dial_enable),
+                        supporting = stringResource(R.string.settings_speed_dial_enable_supporting),
                         leadingIcon = Icons.Outlined.Speed,
                         checked = speedDialEnabled,
                         onCheckedChange = {
@@ -82,7 +84,7 @@ fun SpeedDialScreen(
             }
 
             item {
-                RivoSectionHeader(title = "Assignments")
+                RivoSectionHeader(title = stringResource(R.string.settings_speed_dial_assignments_header))
             }
 
             items(8) { index ->
@@ -118,7 +120,7 @@ fun SpeedDialScreen(
                         
                         Column(modifier = Modifier.weight(1f)) {
                             Text(
-                                text = name ?: "Not assigned",
+                                text = name ?: stringResource(R.string.settings_speed_dial_not_assigned),
                                 style = MaterialTheme.typography.bodyLarge,
                                 fontWeight = FontWeight.SemiBold,
                                 color = if (name == null) MaterialTheme.colorScheme.onSurfaceVariant else MaterialTheme.colorScheme.onSurface
@@ -133,15 +135,15 @@ fun SpeedDialScreen(
                         }
 
                         if (mapping != null) {
-                            IconButton(onClick = { 
+                            IconButton(onClick = {
                                 prefs.setString("speed_dial_$key", null)
                             }) {
-                                Icon(Icons.Default.Delete, contentDescription = "Clear", tint = MaterialTheme.colorScheme.error)
+                                Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.action_clear), tint = MaterialTheme.colorScheme.error)
                             }
                         }
                         
                         IconButton(onClick = { showContactPicker = key }) {
-                            Icon(if (mapping == null) Icons.Default.Add else Icons.Default.Add, contentDescription = "Assign")
+                            Icon(if (mapping == null) Icons.Default.Add else Icons.Default.Add, contentDescription = stringResource(R.string.content_desc_assign))
                         }
                     }
                 }
@@ -195,7 +197,7 @@ fun ContactPickerDialog(
                             TextField(
                                 value = searchQuery,
                                 onValueChange = { searchQuery = it },
-                                placeholder = { Text("Search contact") },
+                                placeholder = { Text(stringResource(R.string.settings_speed_dial_search_contact)) },
                                 modifier = Modifier.fillMaxWidth(),
                                 colors = TextFieldDefaults.colors(
                                     focusedContainerColor = Color.Transparent,
@@ -210,7 +212,7 @@ fun ContactPickerDialog(
                         },
                         navigationIcon = {
                             IconButton(onClick = onDismissRequest) {
-                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                             }
                         },
                         colors = TopAppBarDefaults.topAppBarColors(
@@ -229,7 +231,7 @@ fun ContactPickerDialog(
                     items(filteredContacts) { contact ->
                         RivoListItem(
                             headline = contact.name,
-                            supporting = contact.phoneNumbers.firstOrNull() ?: "No number",
+                            supporting = contact.phoneNumbers.firstOrNull() ?: stringResource(R.string.settings_speed_dial_no_number),
                             avatarName = contact.name,
                             photoUri = contact.photoUri,
                             onClick = { onContactSelected(contact) }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/settings/VoicemailScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/settings/VoicemailScreen.kt
@@ -20,8 +20,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.grinch.rivo4.R
 import com.grinch.rivo4.controller.util.PreferenceManager
 import com.grinch.rivo4.controller.util.getSystemVoicemailNumber
 import com.grinch.rivo4.controller.util.makeCall
@@ -71,22 +73,24 @@ fun VoicemailScreen(
         }
     }
 
-    val currentRingtoneName = remember(ringtoneUri) {
-        if (ringtoneUri == null) "Default"
+    val defaultRingtoneLabel = stringResource(R.string.ringtone_default)
+    val customRingtoneLabel = stringResource(R.string.ringtone_custom)
+    val currentRingtoneName = remember(ringtoneUri, defaultRingtoneLabel, customRingtoneLabel) {
+        if (ringtoneUri == null) defaultRingtoneLabel
         else {
             try {
-                RingtoneManager.getRingtone(context, Uri.parse(ringtoneUri))?.getTitle(context) ?: "Custom"
-            } catch (e: Exception) { "Custom" }
+                RingtoneManager.getRingtone(context, Uri.parse(ringtoneUri))?.getTitle(context) ?: customRingtoneLabel
+            } catch (e: Exception) { customRingtoneLabel }
         }
     }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Voicemail", fontWeight = FontWeight.Bold) },
+                title = { Text(stringResource(R.string.settings_voicemail_title), fontWeight = FontWeight.Bold) },
                 navigationIcon = {
                     IconButton(onClick = { navigator.navigateUp() }) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -101,16 +105,16 @@ fun VoicemailScreen(
         ) {
             item {
                 RivoExpressiveCard(
-                    title = "Carrier Settings",
+                    title = stringResource(R.string.settings_voicemail_carrier_settings),
                     icon = Icons.Outlined.Settings
                 ) {
                     OutlinedTextField(
                         value = voicemailNumber,
-                        onValueChange = { 
+                        onValueChange = {
                             voicemailNumber = it
                             prefs.setString(PreferenceManager.KEY_VOICEMAIL_NUMBER, it)
                         },
-                        label = { Text("Voicemail Number") },
+                        label = { Text(stringResource(R.string.settings_voicemail_number)) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         shape = MaterialTheme.shapes.medium,
@@ -124,29 +128,29 @@ fun VoicemailScreen(
                             }) {
                                 Icon(
                                     imageVector = Icons.Outlined.SimCard,
-                                    contentDescription = "Auto-detect from SIM"
+                                    contentDescription = stringResource(R.string.content_desc_auto_detect_sim)
                                 )
                             }
                         }
                     )
-                    
+
                     Spacer(modifier = Modifier.height(8.dp))
-                    
+
                     Text(
-                        text = "Your carrier's voicemail access number.",
+                        text = stringResource(R.string.settings_voicemail_number_hint),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    
+
                     Spacer(modifier = Modifier.height(16.dp))
                     HorizontalDivider(
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                     )
                     Spacer(modifier = Modifier.height(8.dp))
-                    
+
                     RivoListItem(
-                        headline = "Call Voicemail",
-                        supporting = "Dial your voicemail service directly",
+                        headline = stringResource(R.string.settings_voicemail_call_voicemail),
+                        supporting = stringResource(R.string.settings_voicemail_call_voicemail_supporting),
                         leadingIcon = Icons.Outlined.Voicemail,
                         onClick = {
                             val num = voicemailNumber.ifEmpty { "voicemail:" }
@@ -157,32 +161,33 @@ fun VoicemailScreen(
             }
 
             item {
+                val selectVoicemailNotificationLabel = stringResource(R.string.settings_voicemail_select_notification_ringtone)
                 RivoExpressiveCard(
-                    title = "Notifications",
+                    title = stringResource(R.string.settings_voicemail_notifications_header),
                     icon = Icons.Outlined.Notifications
                 ) {
                     RivoListItem(
-                        headline = "Voicemail Ringtone",
+                        headline = stringResource(R.string.settings_voicemail_ringtone),
                         supporting = currentRingtoneName,
                         leadingIcon = Icons.Outlined.Notifications,
                         onClick = {
                             val intent = Intent(RingtoneManager.ACTION_RINGTONE_PICKER).apply {
                                 putExtra(RingtoneManager.EXTRA_RINGTONE_TYPE, RingtoneManager.TYPE_NOTIFICATION)
-                                putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, "Select Voicemail Notification")
+                                putExtra(RingtoneManager.EXTRA_RINGTONE_TITLE, selectVoicemailNotificationLabel)
                                 putExtra(RingtoneManager.EXTRA_RINGTONE_EXISTING_URI, ringtoneUri?.let { Uri.parse(it) })
                             }
                             ringtonePickerLauncher.launch(intent)
                         }
                     )
-                    
+
                     HorizontalDivider(
                         Modifier.padding(horizontal = 16.dp),
                         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
                     )
-                    
+
                     RivoSwitchListItem(
-                        headline = "Vibration",
-                        supporting = "Vibrate for new voicemail notifications",
+                        headline = stringResource(R.string.settings_voicemail_vibration),
+                        supporting = stringResource(R.string.settings_voicemail_vibration_supporting),
                         leadingIcon = Icons.Outlined.Vibration,
                         checked = vibrationEnabled,
                         onCheckedChange = {
@@ -195,11 +200,11 @@ fun VoicemailScreen(
 
             item {
                 RivoExpressiveCard(
-                    title = "Visual Voicemail",
+                    title = stringResource(R.string.settings_voicemail_visual_header),
                     icon = Icons.Outlined.Voicemail
                 ) {
                     Text(
-                        "Visual Voicemail is currently managed by your carrier. Ensure your carrier app is installed for the best experience.",
+                        stringResource(R.string.settings_voicemail_visual_description),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">RivoPhone</string>
+
+    <!-- Shared actions / generic labels reused across multiple screens -->
+    <string name="action_cancel">Annuler</string>
+    <string name="action_confirm">Confirmer</string>
+    <string name="action_delete">Supprimer</string>
+    <string name="action_save">Enregistrer</string>
+    <string name="action_close">Fermer</string>
+    <string name="action_back">Retour</string>
+    <string name="action_edit">Modifier</string>
+    <string name="action_done">Terminé</string>
+    <string name="action_clear">Effacer</string>
+    <string name="action_clear_selection">Effacer la sélection</string>
+    <string name="action_call">Appeler</string>
+    <string name="action_message">Message</string>
+    <string name="action_add_contact">Ajouter un contact</string>
+    <string name="action_grant_permission">Autoriser</string>
+    <string name="action_grant_permission_lower">Autoriser</string>
+    <string name="action_answer">Répondre</string>
+    <string name="action_decline">Refuser</string>
+    <string name="action_end">Raccrocher</string>
+    <string name="action_mute">Muet</string>
+    <string name="action_keypad">Clavier</string>
+    <string name="action_add_call">Ajouter un appel</string>
+    <string name="action_hold">Mettre en attente</string>
+    <string name="action_resume">Reprendre</string>
+    <string name="action_end_call">Raccrocher</string>
+    <string name="content_desc_selected_item">Sélectionné</string>
+    <string name="select_number_title">Choisir un numéro</string>
+    <string name="select_email_title">Choisir un e-mail</string>
+    <string name="content_desc_remove_favorite">Retirer des favoris</string>
+    <string name="content_desc_select_option">Choisir une option</string>
+    <string name="content_desc_scroll_to_top">Retour en haut</string>
+    <string name="sim_picker_title">Choisir la carte SIM</string>
+    <string name="sim_picker_unknown_sim">SIM inconnue</string>
+    <string name="selection_count_selected">%1$d sélectionné(s)</string>
+    <string name="label_unknown">Inconnu</string>
+    <string name="label_unknown_number">Numéro inconnu</string>
+    <string name="label_mobile">Mobile</string>
+    <string name="label_email">E-mail</string>
+    <string name="label_address">Adresse</string>
+    <string name="label_notes">Notes</string>
+    <string name="label_social_apps">Applications sociales</string>
+    <string name="label_local_memory">Mémoire locale</string>
+    <string name="option_standard">Standard</string>
+    <string name="ringtone_default">Par défaut</string>
+    <string name="ringtone_custom">Personnalisée</string>
+    <string name="empty_state_try_clearing_filters">Essayez de réinitialiser vos filtres ou ajoutez un nouveau contact.</string>
+    <string name="date_today">Aujourd’hui</string>
+    <string name="date_yesterday">Hier</string>
+    <string name="nav_contacts">Contacts</string>
+    <string name="nav_recents">Récents</string>
+    <string name="call_type_incoming">Entrant</string>
+    <string name="call_type_outgoing">Sortant</string>
+    <string name="call_type_missed">Manqué</string>
+    <string name="filter_all">Tous</string>
+    <string name="sim_ask_every_time">Demander à chaque fois</string>
+    <string name="sim_slot_1">SIM 1</string>
+    <string name="sim_slot_2">SIM 2</string>
+    <string name="brand_whatsapp">WhatsApp</string>
+    <string name="brand_telegram">Telegram</string>
+    <string name="brand_signal">Signal</string>
+    <string name="brand_google_meet">Google Meet</string>
+    <string name="brand_zoom">Zoom</string>
+    <string name="account_mi_account">Compte Mi</string>
+    <string name="account_sim_card">Carte SIM</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_skip">Passer</string>
+    <string name="onboarding_next">Suivant</string>
+    <string name="onboarding_get_started">Commencer</string>
+    <string name="onboarding_page1_title">Design expressif</string>
+    <string name="onboarding_page1_description">Découvrez une interface moderne propulsée par Material 3 et des animations Jetpack Compose fluides.</string>
+    <string name="onboarding_page2_title">Numérotation ultra-rapide</string>
+    <string name="onboarding_page2_description">Trouvez vos contacts instantanément grâce à notre recherche T9 intelligente et un historique d’appels organisé.</string>
+    <string name="onboarding_page3_title">Conçu pour vous</string>
+    <string name="onboarding_page3_description">Une expérience d’appel entièrement open source, avec détection de proximité, pensée pour l’efficacité.</string>
+
+    <!-- Patreon support prompt (MainActivity) -->
+    <string name="patreon_prompt_title">Soutenir Rivo</string>
+    <string name="patreon_prompt_confirm">Soutenir sur Patreon</string>
+    <string name="patreon_prompt_dismiss">Plus tard</string>
+    <string name="patreon_prompt_body">Rivo est gratuite et open source. Si vous aimez l’application, pensez à soutenir son développement sur Patreon !</string>
+
+    <!-- Default dialer prompt -->
+    <string name="default_dialer_headline">Faites de Rivo votre application d’appel officielle</string>
+    <string name="default_dialer_description">Pour passer et recevoir des appels, gérer votre historique d’appels et bénéficier de la protection anti-spam, Rivo doit être définie comme application téléphone par défaut.</string>
+    <string name="default_dialer_denied_message">Rivo ne peut pas fonctionner sans cette autorisation. Veuillez réessayer.</string>
+    <string name="default_dialer_set_as_default">Définir par défaut</string>
+
+    <!-- Top bar / bottom navigation -->
+    <string name="top_bar_search_placeholder">Rechercher dans Rivo</string>
+    <string name="content_desc_search">Rechercher</string>
+
+    <!-- Recents / Call log -->
+    <string name="call_history_title">Historique des appels</string>
+    <string name="call_history_with_contact">Historique avec %1$s</string>
+    <string name="call_log_no_history_found">Aucun historique d’appels trouvé</string>
+    <string name="call_log_no_filter_match">Aucun appel ne correspond à ce filtre</string>
+    <string name="call_log_delete_confirm">Voulez-vous vraiment supprimer les %1$d journaux d’appels sélectionnés ?</string>
+    <string name="call_log_delete_title">Supprimer les journaux d’appels</string>
+    <string name="call_log_clear_all_title">Effacer tous les journaux</string>
+    <string name="call_log_clear_all_confirm">Tout effacer</string>
+    <string name="call_log_clear_all_message">Cette action supprimera tout votre historique d’appels. Cette action est irréversible.</string>
+    <string name="content_desc_clear_all_logs">Effacer tous les journaux</string>
+    <string name="content_desc_delete_selected">Supprimer la sélection</string>
+    <string name="recents_permission_title">Historique des appels</string>
+    <string name="recents_permission_description">Rivo a besoin d’accéder à vos journaux d’appels pour afficher votre activité récente et vos appels manqués.</string>
+    <string name="recents_favorites">Favoris</string>
+    <string name="recents_empty_call_log">Votre historique d’appels est vide</string>
+    <string name="content_desc_dialpad">Clavier</string>
+
+    <!-- Contacts list -->
+    <string name="contact_filter_private">Privé</string>
+    <string name="contact_move_to_storage">Déplacer vers un stockage</string>
+    <string name="contact_move_private_storage_title">Stockage privé</string>
+    <string name="contact_move_private_storage_supporting">Stockage réservé à l’application</string>
+    <string name="contact_move_local_memory_supporting">Sur l’appareil uniquement</string>
+    <string name="content_desc_move">Déplacer</string>
+    <string name="contacts_empty_title">Aucun contact trouvé</string>
+    <string name="contacts_permission_rationale">Pour afficher votre liste de contacts et identifier les appels entrants, Rivo a besoin d’accéder à vos contacts.</string>
+
+    <!-- Contact details -->
+    <string name="contact_details_qr_title">QR code du contact</string>
+    <string name="contact_details_qr_content_desc">QR code</string>
+    <string name="contact_details_call">Appeler</string>
+    <string name="contact_details_video">Vidéo</string>
+    <string name="contact_details_info_title">Informations du contact</string>
+    <string name="contact_bullet_favorite">" • Favori"</string>
+    <string name="contact_bullet_recent">" • Récent"</string>
+    <string name="content_desc_favorite">Favori</string>
+    <string name="contact_clear_favorite">Retirer des favoris</string>
+    <string name="contact_set_as_favorite">Définir comme favori</string>
+    <string name="contact_copy_to_clipboard">Copier dans le presse-papiers</string>
+    <string name="contact_clear_default">Retirer par défaut</string>
+    <string name="contact_set_as_default">Définir par défaut</string>
+    <string name="contact_add_to_contacts">Ajouter aux contacts</string>
+    <string name="contact_events_title">Événements et plus</string>
+    <string name="contact_event_birthday">Anniversaire</string>
+    <string name="contact_event_generic">Événement</string>
+    <string name="contact_recent_activity_title">Activité récente</string>
+    <string name="contact_show_full_history">Afficher l’historique complet</string>
+    <string name="contact_settings_title">Paramètres du contact</string>
+    <string name="contact_custom_ringtone">Sonnerie personnalisée</string>
+    <string name="contact_select_ringtone">Choisir une sonnerie</string>
+    <string name="contact_share">Partager le contact</string>
+    <string name="contact_share_description">Envoyer les coordonnées à d’autres personnes</string>
+    <string name="contact_share_text">Nom : %1$s\nTéléphone : %2$s</string>
+    <string name="contact_qr_code">QR code</string>
+    <string name="contact_qr_code_description">Afficher le QR code du contact</string>
+    <string name="contact_move_to_public_storage">Déplacer vers le stockage public</string>
+    <string name="contact_move_to_private_storage">Déplacer vers le stockage privé</string>
+    <string name="contact_visible_to_other_apps">Rendre visible aux autres applications</string>
+    <string name="contact_hidden_from_other_apps">Masquer aux autres applications</string>
+    <string name="contact_remove_from_device">Supprimer ce contact de l’appareil</string>
+    <string name="contact_delete_dialog_title">Supprimer le contact ?</string>
+    <string name="contact_delete_dialog_message">Voulez-vous vraiment supprimer ce contact ? Cette action est irréversible.</string>
+
+    <!-- Contact edit -->
+    <string name="contact_create_title">Créer un contact</string>
+    <string name="contact_edit_title">Modifier le contact</string>
+    <string name="contact_edit_account_header">Compte</string>
+    <string name="contact_edit_save_to_account">Enregistrer dans le compte</string>
+    <string name="contact_edit_private_storage">Stockage privé (application uniquement)</string>
+    <string name="contact_edit_select_account_title">Choisir un compte</string>
+    <string name="contact_edit_private_storage_description">Non visible par les autres applications</string>
+    <string name="contact_edit_identity_header">Identité</string>
+    <string name="contact_edit_full_name">Nom complet</string>
+    <string name="contact_edit_nickname">Surnom</string>
+    <string name="contact_edit_phone_numbers_header">Numéros de téléphone</string>
+    <string name="contact_edit_phone_field_label">Téléphone</string>
+    <string name="contact_edit_add_phone">Ajouter un numéro</string>
+    <string name="contact_edit_emails_header">E-mails</string>
+    <string name="contact_edit_add_email">Ajouter un e-mail</string>
+    <string name="contact_edit_address_header">Adresse</string>
+    <string name="contact_edit_add_address">Ajouter une adresse</string>
+    <string name="contact_edit_notes_header">Notes</string>
+
+    <!-- Dialpad -->
+    <string name="dialpad_title">Clavier</string>
+    <string name="dialpad_start_dialing">Composer un numéro</string>
+    <string name="dialpad_start_hint">Saisissez un nom ou un numéro pour commencer</string>
+    <string name="content_desc_call_named">Appeler %1$s</string>
+    <string name="content_desc_backspace">Effacer</string>
+    <string name="dialpad_connect_via_social">Contacter via les réseaux sociaux</string>
+
+    <!-- Search -->
+    <string name="search_contacts_placeholder">Rechercher des contacts</string>
+    <string name="search_contacts_title">Rechercher des contacts</string>
+    <string name="search_type_to_start">Saisissez un nom ou un numéro pour commencer la recherche</string>
+    <string name="search_no_results_title">Aucun résultat trouvé</string>
+    <string name="search_no_results_hint">Essayez un autre nom ou numéro</string>
+    <string name="search_results_header">Résultats de recherche</string>
+    <string name="search_contacts_permission_title">Autorisation d’accès aux contacts requise</string>
+    <string name="search_contacts_permission_description">Pour rechercher dans vos contacts et identifier les appels entrants, Rivo a besoin d’accéder à vos contacts.</string>
+
+    <!-- Call screen -->
+    <string name="call_screen_sim_label">SIM %1$s</string>
+    <string name="call_status_ended">Appel terminé</string>
+    <string name="call_status_on_hold">En attente</string>
+    <string name="call_status_calling">Appel en cours...</string>
+    <string name="call_status_incoming">Appel entrant</string>
+    <string name="call_status_connecting">Connexion...</string>
+    <string name="audio_route_handset">Combiné</string>
+    <string name="audio_route_speaker">Haut-parleur</string>
+    <string name="audio_route_headset">Casque</string>
+    <string name="audio_route_bluetooth">Bluetooth</string>
+    <string name="audio_route_bluetooth_short">BT</string>
+    <string name="audio_output_title">Sortie audio</string>
+    <string name="swipe_up_to_answer">Glissez vers le haut pour répondre</string>
+    <string name="swipe_down_to_reject">Glissez vers le bas pour refuser</string>
+    <string name="slide_to_answer">glisser pour répondre</string>
+
+    <!-- Call notifications (CallService) -->
+    <string name="notif_channel_calls">Appels</string>
+    <string name="notif_channel_missed_calls">Appels manqués</string>
+    <string name="notif_blocked_call_title">Appel bloqué</string>
+    <string name="notif_blocked_call_text">Appel bloqué de %1$s</string>
+    <string name="notif_missed_call_title">Appel manqué</string>
+    <string name="notif_missed_call_text">Appel manqué de %1$s à %2$s</string>
+    <string name="notif_via_sim">via %1$s</string>
+    <string name="notif_active_call">Appel en cours</string>
+
+    <!-- Backup & restore (status messages) -->
+    <string name="backup_contacts_export_success">Contacts exportés avec succès</string>
+    <string name="backup_contacts_import_success">Contacts importés avec succès</string>
+    <string name="backup_call_logs_export_success">Journaux d’appels exportés avec succès</string>
+    <string name="backup_call_logs_import_success">Journaux d’appels importés avec succès</string>
+    <string name="backup_export_failed">Échec de l’exportation : %1$s</string>
+    <string name="backup_import_failed">Échec de l’importation : %1$s</string>
+
+    <!-- Settings > root -->
+    <string name="settings_title">Paramètres</string>
+    <string name="settings_support_rivo_title">Soutenir Rivo</string>
+    <string name="settings_support_rivo_description">Aidez-nous à garder Rivo gratuite et open source</string>
+    <string name="settings_donate">Faire un don</string>
+    <string name="settings_interface_headline">Interface</string>
+    <string name="settings_interface_supporting">Thème, couleurs et accessibilité</string>
+    <string name="settings_sound_vibration_headline">Son et vibration</string>
+    <string name="settings_sound_vibration_supporting">Sonneries et tonalités du clavier</string>
+    <string name="settings_call_settings_headline">Paramètres d’appel</string>
+    <string name="settings_call_settings_supporting">Gérer les cartes SIM, la numérotation et le rappel automatique</string>
+    <string name="settings_blocked_numbers_headline">Numéros bloqués</string>
+    <string name="settings_blocked_numbers_supporting">Gérer les appels bloqués et le spam</string>
+    <string name="settings_backup_restore_headline">Sauvegarde et restauration</string>
+    <string name="settings_backup_restore_supporting">Importer et exporter les contacts et journaux</string>
+    <string name="settings_manage_contacts_headline">Gérer les contacts</string>
+    <string name="settings_manage_contacts_supporting">Fusionner les doublons et nettoyer votre liste</string>
+    <string name="settings_about_headline">À propos de Rivo</string>
+    <string name="settings_about_supporting">Version, licences et politique de confidentialité</string>
+
+    <!-- Settings > Interface -->
+    <string name="settings_interface_title">Interface utilisateur</string>
+    <string name="settings_interface_restart_required">Un redémarrage est nécessaire pour appliquer entièrement les changements de thème.</string>
+    <string name="settings_interface_restart_action">Redémarrer</string>
+    <string name="settings_interface_material_you">Thème Material You</string>
+    <string name="settings_interface_material_you_supporting">Coloration de l’application basée sur le fond d’écran.</string>
+    <string name="settings_interface_primary_color">Couleur principale</string>
+    <string name="settings_interface_amoled">Mode sombre Amoled</string>
+    <string name="settings_interface_amoled_supporting">Utilise un noir profond pour les éléments de l’interface.</string>
+    <string name="settings_interface_show_first_letter">Afficher la première lettre dans l’avatar</string>
+    <string name="settings_interface_show_first_letter_supporting">Affiche une lettre lorsqu’il n’y a pas de photo</string>
+    <string name="settings_interface_colorful_avatars">Utiliser des avatars colorés</string>
+    <string name="settings_interface_colorful_avatars_supporting">Couleurs aléatoires basées sur le nom du contact</string>
+    <string name="settings_interface_show_picture">Afficher la photo dans l’avatar</string>
+    <string name="settings_interface_show_picture_supporting">Affiche la photo du contact si disponible</string>
+    <string name="settings_interface_avatar_shape">Forme de l’avatar</string>
+    <string name="settings_interface_avatar_shape_supporting">Choisissez la forme des avatars de contact</string>
+    <string name="settings_interface_avatar_shape_squircle">Squircle</string>
+    <string name="settings_interface_avatar_shape_circle">Cercle</string>
+    <string name="settings_interface_avatar_shape_square">Carré</string>
+    <string name="settings_interface_call_screen_avatar">Avatar sur l’écran d’appel</string>
+    <string name="settings_interface_call_screen_avatar_supporting">Afficher la photo du contact sur l’écran d’appel</string>
+    <string name="settings_interface_show_dividers">Afficher les séparateurs</string>
+    <string name="settings_interface_show_dividers_supporting">Afficher des lignes entre les éléments de liste</string>
+    <string name="settings_interface_expressive_cards">Utiliser des cartes expressives</string>
+    <string name="settings_interface_expressive_cards_supporting">Enveloppe les éléments de liste dans des cartes stylisées</string>
+    <string name="settings_interface_transition_animation">Animation de transition</string>
+    <string name="settings_interface_transition_animation_supporting">Style des animations entre les écrans</string>
+    <string name="settings_interface_transition_slide">Glissement</string>
+    <string name="settings_interface_transition_fade">Fondu</string>
+    <string name="settings_interface_transition_none">Aucune</string>
+    <string name="settings_interface_search_matching_mode">Mode de correspondance de recherche</string>
+    <string name="settings_interface_search_matching_mode_supporting">Comportement de l’algorithme de filtrage des contacts</string>
+    <string name="settings_interface_search_mode_t9_contains">T9 et contient</string>
+    <string name="settings_interface_search_mode_starts_with">Commence par</string>
+    <string name="settings_interface_search_mode_exact_match">Correspondance exacte</string>
+    <string name="settings_interface_card_roundness">Arrondi des cartes</string>
+    <string name="settings_interface_card_roundness_supporting">Ajuster le rayon des coins des cartes de l’interface</string>
+    <string name="settings_interface_roundness_extra_round">Très arrondi</string>
+    <string name="settings_interface_roundness_rounded">Arrondi</string>
+    <string name="settings_interface_roundness_semi_square">Semi-carré</string>
+    <string name="settings_interface_roundness_square">Carré</string>
+    <string name="settings_interface_default_bottom_bar">Barre inférieure par défaut</string>
+    <string name="settings_interface_default_bottom_bar_supporting">Choisissez l’onglet ouvert au démarrage</string>
+    <string name="settings_interface_flip_bottom_bar">Inverser la barre inférieure</string>
+    <string name="settings_interface_flip_bottom_bar_supporting">Inverse la position des onglets contacts et récents</string>
+    <string name="settings_interface_icon_only_bar">Barre inférieure avec icônes seules</string>
+    <string name="settings_interface_icon_only_bar_supporting">Supprime les libellés textuels de la navigation</string>
+
+    <!-- Settings > Sound & Vibration -->
+    <string name="settings_sound_title">Son et vibration</string>
+    <string name="settings_sound_dtmf_tone">Tonalité DTMF</string>
+    <string name="settings_sound_dtmf_tone_supporting">Tonalité du clavier jouée lors de l’appui sur une touche</string>
+    <string name="settings_sound_dialpad_vibration">Vibration du clavier</string>
+    <string name="settings_sound_dialpad_vibration_supporting">Vibration du clavier lors de l’appui sur une touche</string>
+    <string name="settings_sound_vibrate_on_answer">Vibrer à la réponse</string>
+    <string name="settings_sound_vibrate_on_answer_supporting">Vibrer lorsque l’interlocuteur répond</string>
+    <string name="settings_sound_vibrate_on_hangup">Vibrer au raccrochage</string>
+    <string name="settings_sound_vibrate_on_hangup_supporting">Vibrer lorsque l’appel se termine</string>
+    <string name="settings_sound_haptic_scroll">Retour haptique au défilement</string>
+    <string name="settings_sound_haptic_scroll_supporting">Vibre légèrement lors du défilement des listes</string>
+    <string name="settings_sound_ringtone_settings">Paramètres de sonnerie</string>
+    <string name="settings_sound_ringtone_settings_supporting">Ouvrir les paramètres sonores du système</string>
+
+    <!-- Settings > Call accounts -->
+    <string name="settings_call_title">Paramètres d’appel</string>
+    <string name="settings_call_speed_dial">Numérotation rapide</string>
+    <string name="settings_call_enabled">Activé</string>
+    <string name="settings_call_disabled">Désactivé</string>
+    <string name="settings_call_default_sim">SIM par défaut</string>
+    <string name="settings_call_calling_accounts">Comptes d’appel</string>
+    <string name="settings_call_calling_accounts_supporting">Configurer les paramètres opérateur (appel en attente, transfert, etc.)</string>
+    <string name="settings_call_t9_dialing">Numérotation T9</string>
+    <string name="settings_call_t9_dialing_supporting">Prédit des mots à partir des touches du clavier numérique</string>
+    <string name="settings_call_proximity_sensor">Capteur de proximité</string>
+    <string name="settings_call_proximity_sensor_supporting">Éteindre l’écran pendant les appels lorsqu’il est près de l’oreille</string>
+    <string name="settings_call_incoming_ui">Interface d’appel entrant</string>
+    <string name="settings_call_incoming_ui_supporting">Choisissez comment répondre aux appels entrants</string>
+    <string name="settings_call_incoming_ui_horizontal_swipe">Glissement horizontal</string>
+    <string name="settings_call_incoming_ui_buttons">Boutons</string>
+    <string name="settings_call_incoming_ui_slide_ios">Glisser pour répondre (iOS)</string>
+    <string name="settings_call_incoming_ui_vertical_swipe">Glissement vertical</string>
+    <string name="settings_call_dialpad_style">Style du clavier</string>
+    <string name="settings_call_dialpad_style_supporting">Apparence visuelle du clavier téléphonique</string>
+    <string name="settings_call_dialpad_style_modern">Moderne</string>
+    <string name="settings_call_dialpad_style_classic">Classique</string>
+    <string name="settings_call_dialpad_style_minimal">Minimaliste</string>
+    <string name="settings_call_dialpad_layout">Disposition du clavier</string>
+    <string name="settings_call_dialpad_layout_supporting">Alignement pour une utilisation à une main</string>
+    <string name="settings_call_dialpad_layout_left">Gauche</string>
+    <string name="settings_call_dialpad_layout_right">Droite</string>
+    <string name="settings_call_auto_redial">Rappel automatique</string>
+    <string name="settings_call_auto_redial_supporting">Rappeler automatiquement si la ligne est occupée</string>
+    <string name="settings_call_redial_attempts">Tentatives de rappel</string>
+    <string name="settings_call_redial_attempts_supporting">Nombre maximal de tentatives de rappel</string>
+    <string name="settings_call_redial_attempts_1">1 tentative</string>
+    <string name="settings_call_redial_attempts_2">2 tentatives</string>
+    <string name="settings_call_redial_attempts_3">3 tentatives</string>
+    <string name="settings_call_redial_attempts_5">5 tentatives</string>
+    <string name="settings_call_redial_attempts_10">10 tentatives</string>
+    <string name="settings_call_redial_delay">Délai de rappel</string>
+    <string name="settings_call_redial_delay_supporting">Délai entre les tentatives de rappel</string>
+    <string name="settings_call_redial_delay_1s">1 seconde</string>
+    <string name="settings_call_redial_delay_2s">2 secondes</string>
+    <string name="settings_call_redial_delay_3s">3 secondes</string>
+    <string name="settings_call_redial_delay_5s">5 secondes</string>
+    <string name="settings_call_redial_delay_10s">10 secondes</string>
+    <string name="settings_call_voicemail">Messagerie vocale</string>
+    <string name="settings_call_voicemail_supporting">Configurer votre messagerie</string>
+
+    <!-- Settings > Blocked numbers -->
+    <string name="settings_blocked_title">Numéros bloqués</string>
+    <string name="settings_blocked_method">Méthode de blocage</string>
+    <string name="settings_blocked_method_supporting">Comment les appels bloqués sont traités</string>
+    <string name="settings_blocked_method_decline">Refuser automatiquement</string>
+    <string name="settings_blocked_method_silent">Sonner en silence</string>
+    <string name="settings_blocked_log_visibility">Visibilité dans le journal</string>
+    <string name="settings_blocked_log_visibility_supporting">Afficher ou masquer les appels bloqués dans les récents</string>
+    <string name="settings_blocked_log_hide">Masquer du journal</string>
+    <string name="settings_blocked_log_show">Afficher dans le journal</string>
+    <string name="settings_blocked_notifications">Notifications de blocage</string>
+    <string name="settings_blocked_notifications_supporting">Afficher une alerte discrète pour les appels bloqués</string>
+    <string name="settings_blocked_system_button">Numéros bloqués du système</string>
+
+    <!-- Settings > Backup & Restore -->
+    <string name="settings_backup_title">Sauvegarde et restauration</string>
+    <string name="settings_backup_contacts_header">Contacts</string>
+    <string name="settings_backup_export_contacts">Exporter les contacts</string>
+    <string name="settings_backup_export_contacts_supporting">Enregistrer les contacts dans un fichier VCF</string>
+    <string name="settings_backup_import_contacts">Importer les contacts</string>
+    <string name="settings_backup_import_contacts_supporting">Restaurer les contacts depuis un fichier VCF</string>
+    <string name="settings_backup_call_logs_header">Journaux d’appels</string>
+    <string name="settings_backup_export_logs">Exporter les journaux d’appels</string>
+    <string name="settings_backup_export_logs_supporting">Enregistrer l’historique dans un fichier JSON</string>
+    <string name="settings_backup_import_logs">Importer les journaux d’appels</string>
+    <string name="settings_backup_import_logs_supporting">Restaurer l’historique depuis un fichier JSON</string>
+
+    <!-- Settings > Manage contacts -->
+    <string name="settings_manage_title">Gérer les contacts</string>
+    <string name="settings_manage_standardizing_title">Normalisation des numéros</string>
+    <string name="settings_manage_percent_completed">%1$d%% terminé</string>
+    <string name="settings_manage_display_sorting">Affichage et tri</string>
+    <string name="settings_manage_sort_by">Trier par</string>
+    <string name="settings_manage_sort_by_supporting">Choisissez comment les contacts sont classés</string>
+    <string name="settings_manage_sort_first_name">Prénom</string>
+    <string name="settings_manage_sort_last_name">Nom</string>
+    <string name="settings_manage_name_format">Format du nom</string>
+    <string name="settings_manage_name_format_supporting">Choisissez comment les noms sont affichés</string>
+    <string name="settings_manage_name_format_first_first">Prénom en premier</string>
+    <string name="settings_manage_name_format_last_first">Nom en premier</string>
+    <string name="settings_manage_storage">Stockage</string>
+    <string name="settings_manage_private_contacts">Contacts privés</string>
+    <string name="settings_manage_private_contacts_supporting">Gérer les contacts stockés uniquement dans cette application</string>
+    <string name="settings_manage_visibility">Visibilité</string>
+    <string name="settings_manage_visibility_supporting">Choisissez les comptes à afficher dans votre liste</string>
+    <string name="settings_manage_quick_fixes">Corrections rapides</string>
+    <string name="settings_manage_standardize_numbers">Normaliser les numéros de téléphone</string>
+    <string name="settings_manage_standardize_numbers_supporting">Supprime les espaces et caractères spéciaux de tous les numéros</string>
+    <string name="settings_manage_no_duplicates">Aucun doublon trouvé.</string>
+    <string name="settings_manage_found_duplicates">%1$d groupes de doublons trouvés</string>
+    <string name="settings_manage_merge_duplicates">Fusionner les doublons</string>
+
+    <!-- Settings > Contact visibility -->
+    <string name="settings_visibility_title">Visibilité des contacts</string>
+    <string name="settings_visibility_description">Choisissez les comptes qui doivent être visibles dans votre liste de contacts. Désélectionner un compte masquera ses contacts sans les supprimer.</string>
+    <string name="settings_visibility_accounts_header">Comptes</string>
+    <string name="settings_visibility_local_memory_supporting">Contacts stockés sur l’appareil</string>
+    <string name="settings_visibility_reset_all">Réinitialiser pour tout afficher</string>
+
+    <!-- Settings > Private contacts -->
+    <string name="settings_private_title">Contacts privés</string>
+    <string name="content_desc_import">Importer</string>
+    <string name="content_desc_export">Exporter</string>
+    <string name="settings_private_empty">Aucun contact privé trouvé</string>
+    <string name="settings_private_manage_hint">Gérez vos contacts locaux chiffrés</string>
+
+    <!-- Settings > Speed dial -->
+    <string name="settings_speed_dial_title">Numérotation rapide</string>
+    <string name="settings_speed_dial_enable">Activer la numérotation rapide</string>
+    <string name="settings_speed_dial_enable_supporting">Appui long sur une touche pour appeler le contact assigné</string>
+    <string name="settings_speed_dial_assignments_header">Assignations</string>
+    <string name="settings_speed_dial_not_assigned">Non assigné</string>
+    <string name="content_desc_assign">Assigner</string>
+    <string name="settings_speed_dial_search_contact">Rechercher un contact</string>
+    <string name="settings_speed_dial_no_number">Aucun numéro</string>
+
+    <!-- Settings > Voicemail -->
+    <string name="settings_voicemail_title">Messagerie vocale</string>
+    <string name="settings_voicemail_carrier_settings">Paramètres opérateur</string>
+    <string name="settings_voicemail_number">Numéro de messagerie vocale</string>
+    <string name="content_desc_auto_detect_sim">Détecter automatiquement depuis la SIM</string>
+    <string name="settings_voicemail_number_hint">Le numéro d’accès à la messagerie vocale de votre opérateur.</string>
+    <string name="settings_voicemail_call_voicemail">Appeler la messagerie vocale</string>
+    <string name="settings_voicemail_call_voicemail_supporting">Composer directement votre service de messagerie vocale</string>
+    <string name="settings_voicemail_notifications_header">Notifications</string>
+    <string name="settings_voicemail_ringtone">Sonnerie de messagerie vocale</string>
+    <string name="settings_voicemail_select_notification_ringtone">Choisir la notification de messagerie vocale</string>
+    <string name="settings_voicemail_vibration">Vibration</string>
+    <string name="settings_voicemail_vibration_supporting">Vibrer pour les nouveaux messages vocaux</string>
+    <string name="settings_voicemail_visual_header">Messagerie vocale visuelle</string>
+    <string name="settings_voicemail_visual_description">La messagerie vocale visuelle est actuellement gérée par votre opérateur. Assurez-vous que l’application de votre opérateur est installée pour une expérience optimale.</string>
+
+    <!-- Settings > About -->
+    <string name="about_title">À propos</string>
+    <string name="about_logo_content_desc">Logo Rivo</string>
+    <string name="about_app_display_name">Rivo</string>
+    <string name="about_app_card_title">À propos de l’application</string>
+    <string name="about_app_card_body">Rivo est une application de numérotation moderne qui allie simplicité et élégance. Conçue avec Material You, elle s’adapte parfaitement à votre thème.</string>
+    <string name="about_version">Version</string>
+    <string name="about_build_number">Numéro de build</string>
+    <string name="contributors_title">Contributeurs</string>
+    <string name="about_contributors_supporting">Découvrez l’équipe derrière le projet</string>
+    <string name="about_patreon">Soutenez-nous sur Patreon</string>
+    <string name="about_patreon_supporting">Aidez à maintenir le projet en vie</string>
+    <string name="about_discord">Serveur Discord</string>
+    <string name="about_discord_supporting">Rejoignez la communauté</string>
+    <string name="about_source_code">Code source</string>
+    <string name="about_source_code_supporting">Voir le code source sur GitHub</string>
+    <string name="about_check_updates">Vérifier les mises à jour</string>
+    <string name="about_current_version">Version actuelle : %1$s</string>
+    <string name="about_copyright">© 2025-2026 Projet RivoPhone</string>
+
+    <!-- Settings > Contributors -->
+    <string name="contributor_role_lead_developer">Développeur principal</string>
+    <string name="contributor_role_developer">Développeur</string>
+
+    <!-- Video calling app picker -->
+    <string name="video_call_title">Appel vidéo</string>
+    <string name="video_call_chooser_with">Appel vidéo avec</string>
+    <string name="video_call_system">Appel vidéo du système</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,484 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">RivoPhone</string>
+
+    <!-- Shared actions / generic labels reused across multiple screens -->
+    <string name="action_cancel">Cancel</string>
+    <string name="action_confirm">Confirm</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_save">Save</string>
+    <string name="action_close">Close</string>
+    <string name="action_back">Back</string>
+    <string name="action_edit">Edit</string>
+    <string name="action_done">Done</string>
+    <string name="action_clear">Clear</string>
+    <string name="action_clear_selection">Clear selection</string>
+    <string name="action_call">Call</string>
+    <string name="action_message">Message</string>
+    <string name="action_add_contact">Add Contact</string>
+    <string name="action_grant_permission">Grant Permission</string>
+    <string name="action_grant_permission_lower">Grant permission</string>
+    <string name="action_answer">Answer</string>
+    <string name="action_decline">Decline</string>
+    <string name="action_end">End</string>
+    <string name="action_mute">Mute</string>
+    <string name="action_keypad">Keypad</string>
+    <string name="action_add_call">Add call</string>
+    <string name="action_hold">Hold</string>
+    <string name="action_resume">Resume</string>
+    <string name="action_end_call">End Call</string>
+    <string name="content_desc_selected_item">Selected</string>
+    <string name="select_number_title">Select Number</string>
+    <string name="select_email_title">Select Email</string>
+    <string name="content_desc_remove_favorite">Remove Favorite</string>
+    <string name="content_desc_select_option">Select option</string>
+    <string name="content_desc_scroll_to_top">Scroll to top</string>
+    <string name="sim_picker_title">Select SIM Card</string>
+    <string name="sim_picker_unknown_sim">Unknown SIM</string>
+    <string name="selection_count_selected">%1$d Selected</string>
+    <string name="label_unknown">Unknown</string>
+    <string name="label_unknown_number">Unknown Number</string>
+    <string name="label_mobile">Mobile</string>
+    <string name="label_email">Email</string>
+    <string name="label_address">Address</string>
+    <string name="label_notes">Notes</string>
+    <string name="label_social_apps">Social Apps</string>
+    <string name="label_local_memory">Local Memory</string>
+    <string name="option_standard">Standard</string>
+    <string name="ringtone_default">Default</string>
+    <string name="ringtone_custom">Custom</string>
+    <string name="empty_state_try_clearing_filters">Try clearing your filters or add a new contact.</string>
+    <string name="date_today">Today</string>
+    <string name="date_yesterday">Yesterday</string>
+    <string name="nav_contacts">Contacts</string>
+    <string name="nav_recents">Recents</string>
+    <string name="call_type_incoming">Incoming</string>
+    <string name="call_type_outgoing">Outgoing</string>
+    <string name="call_type_missed">Missed</string>
+    <string name="filter_all">All</string>
+    <string name="sim_ask_every_time">Ask every time</string>
+    <string name="sim_slot_1">SIM 1</string>
+    <string name="sim_slot_2">SIM 2</string>
+    <string name="brand_whatsapp">WhatsApp</string>
+    <string name="brand_telegram">Telegram</string>
+    <string name="brand_signal">Signal</string>
+    <string name="brand_google_meet">Google Meet</string>
+    <string name="brand_zoom">Zoom</string>
+    <string name="account_mi_account">Mi Account</string>
+    <string name="account_sim_card">SIM Card</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_skip">Skip</string>
+    <string name="onboarding_next">Next</string>
+    <string name="onboarding_get_started">Get Started</string>
+    <string name="onboarding_page1_title">Expressive Design</string>
+    <string name="onboarding_page1_description">Experience a modern interface powered by Material 3 and smooth Jetpack Compose animations.</string>
+    <string name="onboarding_page2_title">Lightning-Fast Dialing</string>
+    <string name="onboarding_page2_description">Find contacts in an instant with our intelligent T9 search and organized call history.</string>
+    <string name="onboarding_page3_title">Built for You</string>
+    <string name="onboarding_page3_description">A fully open-source, proximity-aware calling experience designed for efficiency.</string>
+
+    <!-- Patreon support prompt (MainActivity) -->
+    <string name="patreon_prompt_title">Support Rivo</string>
+    <string name="patreon_prompt_confirm">Support on Patreon</string>
+    <string name="patreon_prompt_dismiss">Maybe later</string>
+    <string name="patreon_prompt_body">Rivo is free and open source. If you like the app, please consider supporting its development on Patreon!</string>
+
+    <!-- Default dialer prompt -->
+    <string name="default_dialer_headline">Make Rivo your official dialer</string>
+    <string name="default_dialer_description">To make and receive calls, manage your call history, and experience spam protection, Rivo needs to be set as your default phone app.</string>
+    <string name="default_dialer_denied_message">Rivo cannot function without this permission. Please try again.</string>
+    <string name="default_dialer_set_as_default">Set as default</string>
+
+    <!-- Top bar / bottom navigation -->
+    <string name="top_bar_search_placeholder">Search in Rivo</string>
+    <string name="content_desc_search">Search</string>
+
+    <!-- Recents / Call log -->
+    <string name="call_history_title">Call History</string>
+    <string name="call_history_with_contact">History with %1$s</string>
+    <string name="call_log_no_history_found">No call history found</string>
+    <string name="call_log_no_filter_match">No calls match this filter</string>
+    <string name="call_log_delete_confirm">Are you sure you want to delete %1$d selected call logs?</string>
+    <string name="call_log_delete_title">Delete Call Logs</string>
+    <string name="call_log_clear_all_title">Clear All Logs</string>
+    <string name="call_log_clear_all_confirm">Clear All</string>
+    <string name="call_log_clear_all_message">This will delete your entire call history. This action cannot be undone.</string>
+    <string name="content_desc_clear_all_logs">Clear all logs</string>
+    <string name="content_desc_delete_selected">Delete selected</string>
+    <string name="recents_permission_title">Call History</string>
+    <string name="recents_permission_description">Rivo needs access to your call logs to show your recent activity and missed calls.</string>
+    <string name="recents_favorites">Favorites</string>
+    <string name="recents_empty_call_log">Your call log is empty</string>
+    <string name="content_desc_dialpad">Dialpad</string>
+
+    <!-- Contacts list -->
+    <string name="contact_filter_private">Private</string>
+    <string name="contact_move_to_storage">Move to Storage</string>
+    <string name="contact_move_private_storage_title">Private Storage</string>
+    <string name="contact_move_private_storage_supporting">App-only storage</string>
+    <string name="contact_move_local_memory_supporting">Device only</string>
+    <string name="content_desc_move">Move</string>
+    <string name="contacts_empty_title">No contacts found</string>
+    <string name="contacts_permission_rationale">To show your contact list and identify incoming calls, Rivo needs permission to access your contacts.</string>
+
+    <!-- Contact details -->
+    <string name="contact_details_qr_title">Contact QR</string>
+    <string name="contact_details_qr_content_desc">QR Code</string>
+    <string name="contact_details_call">Call</string>
+    <string name="contact_details_video">Video</string>
+    <string name="contact_details_info_title">Contact Info</string>
+    <string name="contact_bullet_favorite">" • Favorite"</string>
+    <string name="contact_bullet_recent">" • Recent"</string>
+    <string name="content_desc_favorite">Favorite</string>
+    <string name="contact_clear_favorite">Clear Favorite</string>
+    <string name="contact_set_as_favorite">Set as Favorite</string>
+    <string name="contact_copy_to_clipboard">Copy to Clipboard</string>
+    <string name="contact_clear_default">Clear Default</string>
+    <string name="contact_set_as_default">Set as Default</string>
+    <string name="contact_add_to_contacts">Add to Contacts</string>
+    <string name="contact_events_title">Events &amp; More</string>
+    <string name="contact_event_birthday">Birthday</string>
+    <string name="contact_event_generic">Event</string>
+    <string name="contact_recent_activity_title">Recent Activity</string>
+    <string name="contact_show_full_history">Show full history</string>
+    <string name="contact_settings_title">Contact Settings</string>
+    <string name="contact_custom_ringtone">Custom Ringtone</string>
+    <string name="contact_select_ringtone">Select Ringtone</string>
+    <string name="contact_share">Share Contact</string>
+    <string name="contact_share_description">Send contact details to others</string>
+    <string name="contact_share_text">Name: %1$s\nPhone: %2$s</string>
+    <string name="contact_qr_code">QR Code</string>
+    <string name="contact_qr_code_description">Show contact QR code</string>
+    <string name="contact_move_to_public_storage">Move to Public Storage</string>
+    <string name="contact_move_to_private_storage">Move to Private Storage</string>
+    <string name="contact_visible_to_other_apps">Make visible to other apps</string>
+    <string name="contact_hidden_from_other_apps">Hide from other apps</string>
+    <string name="contact_remove_from_device">Remove this contact from device</string>
+    <string name="contact_delete_dialog_title">Delete Contact?</string>
+    <string name="contact_delete_dialog_message">Are you sure you want to delete this contact? This action cannot be undone.</string>
+
+    <!-- Contact edit -->
+    <string name="contact_create_title">Create Contact</string>
+    <string name="contact_edit_title">Edit Contact</string>
+    <string name="contact_edit_account_header">Account</string>
+    <string name="contact_edit_save_to_account">Save to Account</string>
+    <string name="contact_edit_private_storage">Private Storage (App Only)</string>
+    <string name="contact_edit_select_account_title">Select Account</string>
+    <string name="contact_edit_private_storage_description">Not visible to other apps</string>
+    <string name="contact_edit_identity_header">Identity</string>
+    <string name="contact_edit_full_name">Full Name</string>
+    <string name="contact_edit_nickname">Nickname</string>
+    <string name="contact_edit_phone_numbers_header">Phone Numbers</string>
+    <string name="contact_edit_phone_field_label">Phone</string>
+    <string name="contact_edit_add_phone">Add Phone</string>
+    <string name="contact_edit_emails_header">Emails</string>
+    <string name="contact_edit_add_email">Add Email</string>
+    <string name="contact_edit_address_header">Address</string>
+    <string name="contact_edit_add_address">Add Address</string>
+    <string name="contact_edit_notes_header">Notes</string>
+
+    <!-- Dialpad -->
+    <string name="dialpad_title">Dialpad</string>
+    <string name="dialpad_start_dialing">Start Dialing</string>
+    <string name="dialpad_start_hint">Enter a name or number to start</string>
+    <string name="content_desc_call_named">Call %1$s</string>
+    <string name="content_desc_backspace">Backspace</string>
+    <string name="dialpad_connect_via_social">Connect via Social</string>
+
+    <!-- Search -->
+    <string name="search_contacts_placeholder">Search contacts</string>
+    <string name="search_contacts_title">Search Contacts</string>
+    <string name="search_type_to_start">Type a name or number to start searching</string>
+    <string name="search_no_results_title">No results found</string>
+    <string name="search_no_results_hint">Try a different name or number</string>
+    <string name="search_results_header">Search Results</string>
+    <string name="search_contacts_permission_title">Contacts permission required</string>
+    <string name="search_contacts_permission_description">To search your contacts and identify incoming calls, Rivo needs access to your contacts.</string>
+
+    <!-- Call screen -->
+    <string name="call_screen_sim_label">SIM %1$s</string>
+    <string name="call_status_ended">Call Ended</string>
+    <string name="call_status_on_hold">On Hold</string>
+    <string name="call_status_calling">Calling...</string>
+    <string name="call_status_incoming">Incoming call</string>
+    <string name="call_status_connecting">Connecting...</string>
+    <string name="audio_route_handset">Handset</string>
+    <string name="audio_route_speaker">Speaker</string>
+    <string name="audio_route_headset">Headset</string>
+    <string name="audio_route_bluetooth">Bluetooth</string>
+    <string name="audio_route_bluetooth_short">BT</string>
+    <string name="audio_output_title">Audio Output</string>
+    <string name="swipe_up_to_answer">Swipe up to answer</string>
+    <string name="swipe_down_to_reject">Swipe down to reject</string>
+    <string name="slide_to_answer">slide to answer</string>
+
+    <!-- Call notifications (CallService) -->
+    <string name="notif_channel_calls">Calls</string>
+    <string name="notif_channel_missed_calls">Missed Calls</string>
+    <string name="notif_blocked_call_title">Blocked Call</string>
+    <string name="notif_blocked_call_text">Blocked call from %1$s</string>
+    <string name="notif_missed_call_title">Missed Call</string>
+    <string name="notif_missed_call_text">Missed call from %1$s at %2$s</string>
+    <string name="notif_via_sim">via %1$s</string>
+    <string name="notif_active_call">Active call</string>
+
+    <!-- Backup & restore (status messages) -->
+    <string name="backup_contacts_export_success">Contacts exported successfully</string>
+    <string name="backup_contacts_import_success">Contacts imported successfully</string>
+    <string name="backup_call_logs_export_success">Call logs exported successfully</string>
+    <string name="backup_call_logs_import_success">Call logs imported successfully</string>
+    <string name="backup_export_failed">Export failed: %1$s</string>
+    <string name="backup_import_failed">Import failed: %1$s</string>
+
+    <!-- Settings > root -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_support_rivo_title">Support Rivo</string>
+    <string name="settings_support_rivo_description">Help us keep Rivo free and open source</string>
+    <string name="settings_donate">Donate</string>
+    <string name="settings_interface_headline">Interface</string>
+    <string name="settings_interface_supporting">Theme, colors, and accessibility</string>
+    <string name="settings_sound_vibration_headline">Sound &amp; Vibration</string>
+    <string name="settings_sound_vibration_supporting">Ringtones and dialpad tones</string>
+    <string name="settings_call_settings_headline">Call Settings</string>
+    <string name="settings_call_settings_supporting">Manage SIMs, dialing, and redial</string>
+    <string name="settings_blocked_numbers_headline">Blocked Numbers</string>
+    <string name="settings_blocked_numbers_supporting">Manage blocked calls and spam</string>
+    <string name="settings_backup_restore_headline">Backup &amp; Restore</string>
+    <string name="settings_backup_restore_supporting">Import and export contacts and logs</string>
+    <string name="settings_manage_contacts_headline">Manage Contacts</string>
+    <string name="settings_manage_contacts_supporting">Merge duplicates and clean up your list</string>
+    <string name="settings_about_headline">About Rivo</string>
+    <string name="settings_about_supporting">Version, licenses, and privacy policy</string>
+
+    <!-- Settings > Interface -->
+    <string name="settings_interface_title">User Interface</string>
+    <string name="settings_interface_restart_required">Restart required to apply theme changes fully.</string>
+    <string name="settings_interface_restart_action">Restart</string>
+    <string name="settings_interface_material_you">Material You theming</string>
+    <string name="settings_interface_material_you_supporting">Wallpaper based app color theming.</string>
+    <string name="settings_interface_primary_color">Primary Color</string>
+    <string name="settings_interface_amoled">Amoled dark mode</string>
+    <string name="settings_interface_amoled_supporting">Uses pitch black for UI elements.</string>
+    <string name="settings_interface_show_first_letter">Show first letter in avatar</string>
+    <string name="settings_interface_show_first_letter_supporting">Displays letter when picture is missing</string>
+    <string name="settings_interface_colorful_avatars">Use colorful avatars</string>
+    <string name="settings_interface_colorful_avatars_supporting">Random colors based on contact name</string>
+    <string name="settings_interface_show_picture">Show picture in avatar</string>
+    <string name="settings_interface_show_picture_supporting">Shows the contact picture if available</string>
+    <string name="settings_interface_avatar_shape">Avatar shape</string>
+    <string name="settings_interface_avatar_shape_supporting">Choose the shape for contact avatars</string>
+    <string name="settings_interface_avatar_shape_squircle">Squircle</string>
+    <string name="settings_interface_avatar_shape_circle">Circle</string>
+    <string name="settings_interface_avatar_shape_square">Square</string>
+    <string name="settings_interface_call_screen_avatar">Call screen avatar</string>
+    <string name="settings_interface_call_screen_avatar_supporting">Show contact picture on call screen</string>
+    <string name="settings_interface_show_dividers">Show dividers</string>
+    <string name="settings_interface_show_dividers_supporting">Display lines between list items</string>
+    <string name="settings_interface_expressive_cards">Use expressive cards</string>
+    <string name="settings_interface_expressive_cards_supporting">Wraps list items in styled cards</string>
+    <string name="settings_interface_transition_animation">Transition animation</string>
+    <string name="settings_interface_transition_animation_supporting">Style of animations between screens</string>
+    <string name="settings_interface_transition_slide">Slide</string>
+    <string name="settings_interface_transition_fade">Fade</string>
+    <string name="settings_interface_transition_none">None</string>
+    <string name="settings_interface_search_matching_mode">Search Matching Mode</string>
+    <string name="settings_interface_search_matching_mode_supporting">Behavior of contacts filtering algorithm</string>
+    <string name="settings_interface_search_mode_t9_contains">T9 &amp; Contains</string>
+    <string name="settings_interface_search_mode_starts_with">Starts With</string>
+    <string name="settings_interface_search_mode_exact_match">Exact Match</string>
+    <string name="settings_interface_card_roundness">Card roundness</string>
+    <string name="settings_interface_card_roundness_supporting">Adjust the corner radius of UI cards</string>
+    <string name="settings_interface_roundness_extra_round">Extra Round</string>
+    <string name="settings_interface_roundness_rounded">Rounded</string>
+    <string name="settings_interface_roundness_semi_square">Semi Square</string>
+    <string name="settings_interface_roundness_square">Square</string>
+    <string name="settings_interface_default_bottom_bar">Default bottom bar</string>
+    <string name="settings_interface_default_bottom_bar_supporting">Select which tab opens initially</string>
+    <string name="settings_interface_flip_bottom_bar">Flip bottom bar</string>
+    <string name="settings_interface_flip_bottom_bar_supporting">Flips the position of the contacts &amp; recents tabs</string>
+    <string name="settings_interface_icon_only_bar">Icon-only bottom bar</string>
+    <string name="settings_interface_icon_only_bar_supporting">Removes text labels from navigation</string>
+
+    <!-- Settings > Sound & Vibration -->
+    <string name="settings_sound_title">Sound &amp; Vibration</string>
+    <string name="settings_sound_dtmf_tone">DTMF tone</string>
+    <string name="settings_sound_dtmf_tone_supporting">Dialpad tone that plays during keypress</string>
+    <string name="settings_sound_dialpad_vibration">Dialpad vibration</string>
+    <string name="settings_sound_dialpad_vibration_supporting">Dialpad vibration that plays during keypress</string>
+    <string name="settings_sound_vibrate_on_answer">Vibrate on Answer</string>
+    <string name="settings_sound_vibrate_on_answer_supporting">Vibrate when the other party answers</string>
+    <string name="settings_sound_vibrate_on_hangup">Vibrate on Hang up</string>
+    <string name="settings_sound_vibrate_on_hangup_supporting">Vibrate when the call ends</string>
+    <string name="settings_sound_haptic_scroll">Haptic Scrolling feedback</string>
+    <string name="settings_sound_haptic_scroll_supporting">Vibrate subtly when scrolling lists</string>
+    <string name="settings_sound_ringtone_settings">Ringtone Settings</string>
+    <string name="settings_sound_ringtone_settings_supporting">Open system sound settings</string>
+
+    <!-- Settings > Call accounts -->
+    <string name="settings_call_title">Call Settings</string>
+    <string name="settings_call_speed_dial">Speed dial</string>
+    <string name="settings_call_enabled">Enabled</string>
+    <string name="settings_call_disabled">Disabled</string>
+    <string name="settings_call_default_sim">Default SIM</string>
+    <string name="settings_call_calling_accounts">Calling accounts</string>
+    <string name="settings_call_calling_accounts_supporting">Configure carrier settings (Call Waiting, Forwarding, etc.)</string>
+    <string name="settings_call_t9_dialing">T9 Dialing</string>
+    <string name="settings_call_t9_dialing_supporting">Predicts words from numeric keypad inputs</string>
+    <string name="settings_call_proximity_sensor">Proximity Sensor</string>
+    <string name="settings_call_proximity_sensor_supporting">Turn off screen during calls when near ear</string>
+    <string name="settings_call_incoming_ui">Incoming Call UI</string>
+    <string name="settings_call_incoming_ui_supporting">Choose how to answer incoming calls</string>
+    <string name="settings_call_incoming_ui_horizontal_swipe">Horizontal Swipe</string>
+    <string name="settings_call_incoming_ui_buttons">Buttons</string>
+    <string name="settings_call_incoming_ui_slide_ios">Slide to Answer (iOS)</string>
+    <string name="settings_call_incoming_ui_vertical_swipe">Vertical Swipe</string>
+    <string name="settings_call_dialpad_style">Dialpad Style</string>
+    <string name="settings_call_dialpad_style_supporting">Visual appearance of the phone dialer</string>
+    <string name="settings_call_dialpad_style_modern">Modern</string>
+    <string name="settings_call_dialpad_style_classic">Classic</string>
+    <string name="settings_call_dialpad_style_minimal">Minimal</string>
+    <string name="settings_call_dialpad_layout">Dialpad Layout</string>
+    <string name="settings_call_dialpad_layout_supporting">Alignment for one-handed use</string>
+    <string name="settings_call_dialpad_layout_left">Left</string>
+    <string name="settings_call_dialpad_layout_right">Right</string>
+    <string name="settings_call_auto_redial">Auto Redial</string>
+    <string name="settings_call_auto_redial_supporting">Automatically redial if the line is busy</string>
+    <string name="settings_call_redial_attempts">Redial Attempts</string>
+    <string name="settings_call_redial_attempts_supporting">Maximum number of redial attempts</string>
+    <string name="settings_call_redial_attempts_1">1 attempt</string>
+    <string name="settings_call_redial_attempts_2">2 attempts</string>
+    <string name="settings_call_redial_attempts_3">3 attempts</string>
+    <string name="settings_call_redial_attempts_5">5 attempts</string>
+    <string name="settings_call_redial_attempts_10">10 attempts</string>
+    <string name="settings_call_redial_delay">Redial Delay</string>
+    <string name="settings_call_redial_delay_supporting">Delay between redial attempts</string>
+    <string name="settings_call_redial_delay_1s">1 second</string>
+    <string name="settings_call_redial_delay_2s">2 seconds</string>
+    <string name="settings_call_redial_delay_3s">3 seconds</string>
+    <string name="settings_call_redial_delay_5s">5 seconds</string>
+    <string name="settings_call_redial_delay_10s">10 seconds</string>
+    <string name="settings_call_voicemail">Voicemail</string>
+    <string name="settings_call_voicemail_supporting">Configure your mailbox</string>
+
+    <!-- Settings > Blocked numbers -->
+    <string name="settings_blocked_title">Blocked Numbers</string>
+    <string name="settings_blocked_method">Block method</string>
+    <string name="settings_blocked_method_supporting">How blocked calls are handled</string>
+    <string name="settings_blocked_method_decline">Decline automatically</string>
+    <string name="settings_blocked_method_silent">Ring silently</string>
+    <string name="settings_blocked_log_visibility">Log visibility</string>
+    <string name="settings_blocked_log_visibility_supporting">Show or hide blocked calls in recents</string>
+    <string name="settings_blocked_log_hide">Hide from logs</string>
+    <string name="settings_blocked_log_show">Show in logs</string>
+    <string name="settings_blocked_notifications">Block notifications</string>
+    <string name="settings_blocked_notifications_supporting">Show a low-priority alert for blocked calls</string>
+    <string name="settings_blocked_system_button">System Blocked Numbers</string>
+
+    <!-- Settings > Backup & Restore -->
+    <string name="settings_backup_title">Backup &amp; Restore</string>
+    <string name="settings_backup_contacts_header">Contacts</string>
+    <string name="settings_backup_export_contacts">Export Contacts</string>
+    <string name="settings_backup_export_contacts_supporting">Save contacts to a VCF file</string>
+    <string name="settings_backup_import_contacts">Import Contacts</string>
+    <string name="settings_backup_import_contacts_supporting">Restore contacts from a VCF file</string>
+    <string name="settings_backup_call_logs_header">Call Logs</string>
+    <string name="settings_backup_export_logs">Export Call Logs</string>
+    <string name="settings_backup_export_logs_supporting">Save history to a JSON file</string>
+    <string name="settings_backup_import_logs">Import Call Logs</string>
+    <string name="settings_backup_import_logs_supporting">Restore history from a JSON file</string>
+
+    <!-- Settings > Manage contacts -->
+    <string name="settings_manage_title">Manage Contacts</string>
+    <string name="settings_manage_standardizing_title">Standardizing numbers</string>
+    <string name="settings_manage_percent_completed">%1$d%% completed</string>
+    <string name="settings_manage_display_sorting">Display &amp; Sorting</string>
+    <string name="settings_manage_sort_by">Sort by</string>
+    <string name="settings_manage_sort_by_supporting">Choose how contacts are ordered</string>
+    <string name="settings_manage_sort_first_name">First Name</string>
+    <string name="settings_manage_sort_last_name">Last Name</string>
+    <string name="settings_manage_name_format">Name format</string>
+    <string name="settings_manage_name_format_supporting">Choose how names are displayed</string>
+    <string name="settings_manage_name_format_first_first">First Name First</string>
+    <string name="settings_manage_name_format_last_first">Last Name First</string>
+    <string name="settings_manage_storage">Storage</string>
+    <string name="settings_manage_private_contacts">Private Contacts</string>
+    <string name="settings_manage_private_contacts_supporting">Manage contacts stored only in this app</string>
+    <string name="settings_manage_visibility">Visibility</string>
+    <string name="settings_manage_visibility_supporting">Choose which accounts to show in your list</string>
+    <string name="settings_manage_quick_fixes">Quick Fixes</string>
+    <string name="settings_manage_standardize_numbers">Standardize phone numbers</string>
+    <string name="settings_manage_standardize_numbers_supporting">Remove spaces and special characters from all numbers</string>
+    <string name="settings_manage_no_duplicates">No duplicates found.</string>
+    <string name="settings_manage_found_duplicates">Found %1$d groups of duplicates</string>
+    <string name="settings_manage_merge_duplicates">Merge duplicates</string>
+
+    <!-- Settings > Contact visibility -->
+    <string name="settings_visibility_title">Contact Visibility</string>
+    <string name="settings_visibility_description">Select which accounts should be visible in your contact list. Deselecting an account will hide its contacts but won\'t delete them.</string>
+    <string name="settings_visibility_accounts_header">Accounts</string>
+    <string name="settings_visibility_local_memory_supporting">Contacts stored on device</string>
+    <string name="settings_visibility_reset_all">Reset to Show All</string>
+
+    <!-- Settings > Private contacts -->
+    <string name="settings_private_title">Private Contacts</string>
+    <string name="content_desc_import">Import</string>
+    <string name="content_desc_export">Export</string>
+    <string name="settings_private_empty">No private contacts found</string>
+    <string name="settings_private_manage_hint">Manage your encrypted local contacts</string>
+
+    <!-- Settings > Speed dial -->
+    <string name="settings_speed_dial_title">Speed Dial</string>
+    <string name="settings_speed_dial_enable">Enable Speed Dial</string>
+    <string name="settings_speed_dial_enable_supporting">Long press a key to call assigned contact</string>
+    <string name="settings_speed_dial_assignments_header">Assignments</string>
+    <string name="settings_speed_dial_not_assigned">Not assigned</string>
+    <string name="content_desc_assign">Assign</string>
+    <string name="settings_speed_dial_search_contact">Search contact</string>
+    <string name="settings_speed_dial_no_number">No number</string>
+
+    <!-- Settings > Voicemail -->
+    <string name="settings_voicemail_title">Voicemail</string>
+    <string name="settings_voicemail_carrier_settings">Carrier Settings</string>
+    <string name="settings_voicemail_number">Voicemail Number</string>
+    <string name="content_desc_auto_detect_sim">Auto-detect from SIM</string>
+    <string name="settings_voicemail_number_hint">Your carrier\'s voicemail access number.</string>
+    <string name="settings_voicemail_call_voicemail">Call Voicemail</string>
+    <string name="settings_voicemail_call_voicemail_supporting">Dial your voicemail service directly</string>
+    <string name="settings_voicemail_notifications_header">Notifications</string>
+    <string name="settings_voicemail_ringtone">Voicemail Ringtone</string>
+    <string name="settings_voicemail_select_notification_ringtone">Select Voicemail Notification</string>
+    <string name="settings_voicemail_vibration">Vibration</string>
+    <string name="settings_voicemail_vibration_supporting">Vibrate for new voicemail notifications</string>
+    <string name="settings_voicemail_visual_header">Visual Voicemail</string>
+    <string name="settings_voicemail_visual_description">Visual Voicemail is currently managed by your carrier. Ensure your carrier app is installed for the best experience.</string>
+
+    <!-- Settings > About -->
+    <string name="about_title">About</string>
+    <string name="about_logo_content_desc">Rivo Logo</string>
+    <string name="about_app_display_name">Rivo</string>
+    <string name="about_app_card_title">About the App</string>
+    <string name="about_app_card_body">Rivo is a modern dialer app that brings simplicity and elegance to calling. Designed with Material You, it adapts seamlessly to your theme.</string>
+    <string name="about_version">Version</string>
+    <string name="about_build_number">Build number</string>
+    <string name="contributors_title">Contributors</string>
+    <string name="about_contributors_supporting">Meet the team behind the project</string>
+    <string name="about_patreon">Support Us on Patreon</string>
+    <string name="about_patreon_supporting">Help keep the project alive</string>
+    <string name="about_discord">Discord Server</string>
+    <string name="about_discord_supporting">Join the community</string>
+    <string name="about_source_code">Source Code</string>
+    <string name="about_source_code_supporting">View the source code on GitHub</string>
+    <string name="about_check_updates">Check for Updates</string>
+    <string name="about_current_version">Current version: %1$s</string>
+    <string name="about_copyright">© 2025-2026 RivoPhone Project</string>
+
+    <!-- Settings > Contributors -->
+    <string name="contributor_role_lead_developer">Lead Developer</string>
+    <string name="contributor_role_developer">Developer</string>
+
+    <!-- Video calling app picker -->
+    <string name="video_call_title">Video Call</string>
+    <string name="video_call_chooser_with">Video Call with</string>
+    <string name="video_call_system">System Video Call</string>
 </resources>


### PR DESCRIPTION
This PR makes the app translatable and ships French as the first translation, since I'm a native French speaker. Closes #82.

- All user-facing text now goes through resources: `res/values/strings.xml` (English, original wording unchanged) and `res/values-fr/strings.xml`.
- The app language follows the system locale, with automatic fallback to English for any key missing in French, native Android behavior, no language-picker code to maintain.
- Fixed 2-3 comparisons along the way that relied on a displayed label instead of a stable value (a filter, a keyboard type) a latent bug that would have surfaced as soon as translation was introduced.
- The app also shows up in Android 13+'s per-app language picker (Settings > Languages > App languages) auto-generated from the same resources, no UI or extra code involved.

Diff is large but uniform: half of it is the two `strings.xml` files. No behavior changes.

## Adding another language
1. Copy `res/values/strings.xml` to `res/values-<code>/strings.xml` (e.g. `values-de`, `values-es`)
2. Translate the text, keep the `name` attributes as-is
3. Missing keys fall back to English automatically, no code changes needed

## 🧪 Tested

- [x] Build pass with Android Studio
- [x] Tested on an Oppo Reno 13 Pro (Android 16).
- [x] Per-app language switch verified