### PR TITLE
Name release APK/AAB after the app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,24 @@ android {
         //     universalApk = true
         }
     }
+
+    applicationVariants.all { variant ->
+        variant.outputs.all { output ->
+            outputFileName = "RivoPhone-${variant.versionName}.apk"
+        }
+    }
+}
+
+afterEvaluate {
+    tasks.named("bundleRelease").configure {
+        doLast {
+            def outDir = layout.buildDirectory.dir("outputs/bundle/release").get().asFile
+            def original = new File(outDir, "app-release.aab")
+            if (original.exists()) {
+                original.renameTo(new File(outDir, "RivoPhone-${android.defaultConfig.versionName}.aab"))
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Renames release artifacts to RivoPhone-<version>.apk / .aab instead of the generic app-release default.

Tools like Obtainium/Omnify or equivalent can rely on release filenames to track available updates, and a generic name makes that less reliable. No behavior change, just the filenames produced by assembleRelease/bundleRelease.

## 🧪 Tested

- [x] Build pass with Android Studio 
- [x] Verified output filenames for both assembleRelease (APK) and bundleRelease (AAB)