### PR TITLE
Fix layouts that break on a larger display or font size

### DIFF
--- a/app/src/main/java/com/grinch/rivo4/view/components/RivoExpressiveUI.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/components/RivoExpressiveUI.kt
@@ -205,7 +205,7 @@ fun RivoExpressiveButton(
     Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
         Surface(
             onClick = onClick,
-            modifier = Modifier.height(size).width(size * 1.3f),
+            modifier = Modifier.height(size).widthIn(max = size * 1.3f).fillMaxWidth(),
             shape = RoundedCornerShape(cornerRadius),
             color = containerColor,
             contentColor = contentColor,
@@ -222,7 +222,15 @@ fun RivoExpressiveButton(
         }
         if (label != null) {
             Spacer(modifier = Modifier.height(8.dp))
-            Text(text = label, style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurface, fontWeight = FontWeight.Medium)
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+            )
         }
     }
 }
@@ -321,7 +329,7 @@ fun RivoListItem(
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.SemiBold,
                     color = headlineColor,
-                    maxLines = 1,
+                    maxLines = 2,
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                 )
                 if (supporting != null) {
@@ -329,7 +337,7 @@ fun RivoListItem(
                         text = supporting,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                     )
                 }
@@ -452,7 +460,7 @@ fun RivoSelectListItem(
                     text = headline,
                     style = MaterialTheme.typography.bodyLarge,
                     fontWeight = FontWeight.SemiBold,
-                    maxLines = 1,
+                    maxLines = 2,
                     overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                 )
                 if (supporting != null) {
@@ -460,7 +468,7 @@ fun RivoSelectListItem(
                         text = supporting,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
+                        maxLines = 2,
                         overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
                     )
                 }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
@@ -442,7 +442,7 @@ fun ExpressiveCallScreen(
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceEvenly,
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.Top
                         ) {
                             CallActionButton(
                                 icon = if (isMuted) Icons.Default.MicOff else Icons.Default.Mic,
@@ -479,7 +479,7 @@ fun ExpressiveCallScreen(
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceEvenly,
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalAlignment = Alignment.Top
                         ) {
                             val audioRoute = audioState?.route ?: CallAudioState.ROUTE_EARPIECE
                             val audioIcon = when (audioRoute) {
@@ -879,7 +879,10 @@ fun CallActionButton(
             text = label,
             style = MaterialTheme.typography.labelLarge,
             color = MaterialTheme.colorScheme.onSurface,
-            fontWeight = FontWeight.Medium
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
@@ -899,11 +899,13 @@ fun HorizontalSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit) {
     val isDark = isSystemInDarkTheme()
 
     val trackHeight = 96.dp // Increased from 88.dp
-    val handleWidth = 110.dp
+    val maxHandleWidth = 110.dp
     val handleHeight = 72.dp // Increased from 64.dp
-    val handleWidthPx = with(density) { handleWidth.toPx() }
     var trackWidthPx by remember { mutableFloatStateOf(0f) }
-    
+    val trackWidth = with(density) { trackWidthPx.toDp() }
+    val handleWidth = if (trackWidthPx > 0f) (trackWidth * 0.32f).coerceAtMost(maxHandleWidth) else maxHandleWidth
+    val handleWidthPx = with(density) { handleWidth.toPx() }
+
     val maxDrag by remember(trackWidthPx, handleWidthPx) {
         derivedStateOf {
             if (trackWidthPx > 0f) (trackWidthPx / 2f) - (handleWidthPx / 2f) - with(density) { 12.dp.toPx() }
@@ -971,27 +973,38 @@ fun HorizontalSwipeToAnswer(onAnswer: () -> Unit, onDecline: () -> Unit) {
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.2f))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.2f), CircleShape)
     ) {
-        Text(
-            stringResource(R.string.action_decline),
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .padding(start = 32.dp)
-                .alpha((1f - (dragProgress.value * -2f).coerceIn(0f, 1f)) * hintAlpha),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = declineRed.copy(alpha = 0.8f)
-        )
+        Row(
+            modifier = Modifier.fillMaxSize(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.action_decline),
+                modifier = Modifier
+                    .weight(1f)
+                    .alpha((1f - (dragProgress.value * -2f).coerceIn(0f, 1f)) * hintAlpha),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = declineRed.copy(alpha = 0.8f),
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
 
-        Text(
-            stringResource(R.string.action_answer),
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .padding(end = 32.dp)
-                .alpha((1f - (dragProgress.value * 2f).coerceIn(0f, 1f)) * hintAlpha),
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            color = answerGreen.copy(alpha = 0.8f)
-        )
+            Spacer(modifier = Modifier.width(handleWidth))
+
+            Text(
+                stringResource(R.string.action_answer),
+                modifier = Modifier
+                    .weight(1f)
+                    .alpha((1f - (dragProgress.value * 2f).coerceIn(0f, 1f)) * hintAlpha),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = answerGreen.copy(alpha = 0.8f),
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
 
         // drag handle
         Box(

--- a/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/CallScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.grinch.rivo4.R
@@ -727,16 +728,18 @@ fun PulsingAvatar(photoUri: String?) {
         label = "alpha"
     )
 
+    val avatarSize = heroAvatarSize(isLandscape = false)
+
     Box(contentAlignment = Alignment.Center) {
         Box(
             modifier = Modifier
-                .size(180.dp)
+                .size(avatarSize * 0.9f)
                 .scale(scale)
                 .border(2.dp, MaterialTheme.colorScheme.primary.copy(alpha = alpha), CircleShape)
         )
         Box(
             modifier = Modifier
-                .size(220.dp)
+                .size(avatarSize * 1.1f)
                 .scale(scale * 1.2f)
                 .border(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = alpha * 0.5f), CircleShape)
         )
@@ -796,6 +799,13 @@ fun FloatingParticles() {
 }
 
 @Composable
+private fun heroAvatarSize(isLandscape: Boolean): Dp {
+    val configuration = LocalConfiguration.current
+    return if (isLandscape) 120.dp
+           else (configuration.screenHeightDp.dp * 0.22f).coerceAtMost(200.dp)
+}
+
+@Composable
 fun HeroAvatar(photoUri: String?, isLandscape: Boolean = false) {
     val prefs = koinInject<PreferenceManager>()
     val settingsState by prefs.settingsChanged.collectAsState()
@@ -809,8 +819,8 @@ fun HeroAvatar(photoUri: String?, isLandscape: Boolean = false) {
         }
     }
 
-    val size = if (isLandscape) 120.dp else 200.dp
-    val iconSize = if (isLandscape) 72.dp else 120.dp
+    val size = heroAvatarSize(isLandscape)
+    val iconSize = size * 0.6f
 
     Box(
         modifier = Modifier

--- a/app/src/main/java/com/grinch/rivo4/view/screen/ContactDetails.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/ContactDetails.kt
@@ -353,7 +353,7 @@ fun ContactDetailsScreen(
                     item {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceEvenly
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             RivoExpressiveButton(
                                 icon = Icons.Default.Call,
@@ -361,7 +361,8 @@ fun ContactDetailsScreen(
                                 containerColor = MaterialTheme.colorScheme.primaryContainer,
                                 onClick = {
                                     callLauncher.dial(if (fullContact == null) displayPhone else "", fullContact)
-                                }
+                                },
+                                modifier = Modifier.weight(1f)
                             )
                             RivoExpressiveButton(
                                 icon = Icons.AutoMirrored.Filled.Message,
@@ -369,7 +370,8 @@ fun ContactDetailsScreen(
                                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                                 onClick = {
                                     messageLauncher.sendMessage(if (fullContact == null) displayPhone else "", fullContact)
-                                }
+                                },
+                                modifier = Modifier.weight(1f)
                             )
                             RivoExpressiveButton(
                                 icon = Icons.Default.VideoCall,
@@ -377,7 +379,8 @@ fun ContactDetailsScreen(
                                 containerColor = MaterialTheme.colorScheme.secondaryContainer,
                                 onClick = {
                                     videoLauncher.startVideoCall(displayPhone, fullContact)
-                                }
+                                },
+                                modifier = Modifier.weight(1f)
                             )
                             val hasEmails = fullContact?.emails?.isNotEmpty() == true
                             RivoExpressiveButton(
@@ -389,7 +392,8 @@ fun ContactDetailsScreen(
                                     if (hasEmails) {
                                         emailLauncher.sendEmail("", fullContact)
                                     }
-                                }
+                                },
+                                modifier = Modifier.weight(1f)
                             )
                         }
                     }

--- a/app/src/main/java/com/grinch/rivo4/view/screen/onboarding/MorphingOnboardingScreen.kt
+++ b/app/src/main/java/com/grinch/rivo4/view/screen/onboarding/MorphingOnboardingScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Dialpad
@@ -133,6 +135,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
                 onClick = onFinished,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
+                    .statusBarsPadding()
                     .padding(16.dp)
             ) {
                 Text(stringResource(R.string.onboarding_skip))
@@ -141,6 +144,7 @@ fun MorphingOnboardingScreen(onFinished: () -> Unit) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
+                    .systemBarsPadding()
                     .padding(24.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {


### PR DESCRIPTION
On some devices several screens render badly: buttons stuck together, text
sliding underneath another element, descriptions cut off with an ellipsis.

What they have in common: these screens were built with fixed sizes. Every
element claimed its space up front, and the gap between them was only whatever
was left over. On an emulator at factory settings there is enough slack, so
everything looks fine. Raise Android's display size or font size and that slack
disappears, so elements end up touching or overlapping.

That is what makes this one sneaky: my Oppo Reno 13 Pro has a physically larger
screen, yet Android reports it to apps as narrower because of its density. No
exotic setting involved, just a configuration outside the one that was tested.

Screens at factory settings are deliberately left unchanged.

## What is fixed

### Contact details

The four Call / Message / Video / Email buttons were stuck together. They now
share the available width with a guaranteed gap.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/bfd21f4c-677d-4db9-bc2e-d93a765cde27" width="320" alt="Before"> | <img src="https://github.com/user-attachments/assets/59e9c7b5-e4ca-45c8-b544-244dd6e87ea4" width="320" alt="After"> |

### Incoming call

The Decline and Answer labels slid underneath the middle button. Each one now
has its own reserved zone, so overlapping is no longer possible.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/fc82a262-b56d-49ff-a103-155ed6180ef1" width="320" alt="Before"> | <img src="https://github.com/user-attachments/assets/f36ca6bd-cbd0-4dec-a57e-d1e4aab9f3d1" width="320" alt="After"> |

### Settings

Titles and descriptions were capped at a single line and got cut off. They can
now wrap to two lines.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/94c1ff91-04df-4dba-89bf-219de5e0aa71" width="320" alt="Before"> | <img src="https://github.com/user-attachments/assets/c5934245-a300-473f-b881-ba5e75bc037a" width="320" alt="After"> |

### During a call

Labels that wrapped to two lines were not centered, and since the columns no
longer had the same height, the buttons stopped lining up with each other. The
avatar took up so much room that it ended up touching the buttons below it, it
now adapts to the screen height.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/8403f6bb-3951-40bf-a304-cdeb1c4fbfde" width="320" alt="Before"> | <img src="https://github.com/user-attachments/assets/2d57448b-3592-46b8-8ab4-0e77cf9bfa23" width="320" alt="After"> |

### First launch

The Skip and Next buttons were hidden behind the status bar and the navigation
bar. This one has nothing to do with density, it showed up on any device.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/3928bee7-72b7-4ccb-b3cf-f862ddca50ff" width="320" alt="Before"> | <img src="https://github.com/user-attachments/assets/7a9edd45-a81a-429c-97b1-f5501b73771e" width="320" alt="After"> |

## 🧪 Tested

- [x] Build passes in Android Studio
- [x] Tested on an Oppo Reno 13 Pro (Android 16), and on the Android Studio emulator with a Pixel 10 and Pixel 10 XL running Android 16 and 17